### PR TITLE
Add platform TLS and initial workloads

### DIFF
--- a/docs/04-platform-and-apps.md
+++ b/docs/04-platform-and-apps.md
@@ -1,0 +1,21 @@
+# Chunk 4 — Platform TLS & first workloads
+
+This chunk:
+- Sets Traefik as a **LoadBalancer** with fixed IP `172.22.10.60` (MetalLB).
+- Installs a default TLS cert (our wildcard `*.lab.local`) via a Traefik **TLSStore**.
+- Deploys **Caldera** (namespace `soc`), **DVWA** (`victim`), and **Kali CLI** (`red`).
+- Updates Windows **hosts** for clean URLs.
+
+## Apply
+```powershell
+pwsh -File .\scripts\gen-ssl.ps1
+pwsh -File .\scripts\apply-k8s.ps1
+
+URLs
+
+    https://caldera.lab.local (admin/admin)
+
+    https://dvwa.lab.local
+
+    https://portainer.lab.local:9443 (after LB IP appears in kubectl -n portainer get svc portainer)
+```

--- a/k8s/apps/caldera/deployment.yaml
+++ b/k8s/apps/caldera/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caldera
+  namespace: soc
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: caldera } }
+  template:
+    metadata: { labels: { app: caldera } }
+    spec:
+      containers:
+        - name: caldera
+          image: mitre/caldera:latest
+          imagePullPolicy: IfNotPresent
+          ports: [{containerPort: 8888}]
+          env:
+            - { name: CALDERA_ADMIN, value: "admin" }
+            - { name: CALDERA_PASSWORD, value: "admin" }  # lab-only
+          readinessProbe:
+            httpGet: { path: /, port: 8888 }
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /, port: 8888 }
+            initialDelaySeconds: 60
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: caldera
+  namespace: soc
+spec:
+  type: ClusterIP
+  selector: { app: caldera }
+  ports:
+    - { name: http, port: 8888, targetPort: 8888 }
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: caldera
+  namespace: soc
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: caldera.lab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: { name: caldera, port: { number: 8888 } }

--- a/k8s/apps/dvwa/deployment.yaml
+++ b/k8s/apps/dvwa/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dvwa
+  namespace: victim
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: dvwa } }
+  template:
+    metadata: { labels: { app: dvwa } }
+    spec:
+      containers:
+        - name: dvwa
+          image: vulnerables/web-dvwa:latest
+          imagePullPolicy: IfNotPresent
+          ports: [{containerPort: 80}]
+          readinessProbe:
+            httpGet: { path: /login.php, port: 80 }
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /, port: 80 }
+            initialDelaySeconds: 30
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dvwa
+  namespace: victim
+spec:
+  type: ClusterIP
+  selector: { app: dvwa }
+  ports:
+    - { name: http, port: 80, targetPort: 80 }
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dvwa
+  namespace: victim
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: dvwa.lab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: { name: dvwa, port: { number: 80 } }

--- a/k8s/apps/kali/deployment.yaml
+++ b/k8s/apps/kali/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kali-cli
+  namespace: red
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: kali-cli } }
+  template:
+    metadata: { labels: { app: kali-cli } }
+    spec:
+      containers:
+        - name: kali
+          image: kalilinux/kali-rolling
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh","-c","sleep infinity"]
+          resources:
+            requests: { cpu: "200m", memory: "256Mi" }
+            limits:   { cpu: "1",    memory: "1Gi" }

--- a/k8s/ingress/traefik-tlsstore.yaml
+++ b/k8s/ingress/traefik-tlsstore.yaml
@@ -1,0 +1,9 @@
+# Default TLS for Traefik using our wildcard cert
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+  namespace: kube-system   # k3s deploys Traefik in kube-system by default
+spec:
+  defaultCertificate:
+    secretName: wildcard-lab-local-tls

--- a/k8s/namespaces.yaml
+++ b/k8s/namespaces.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata: { name: soc }
+---
+apiVersion: v1
+kind: Namespace
+metadata: { name: victim }
+---
+apiVersion: v1
+kind: Namespace
+metadata: { name: red }

--- a/scripts/apply-k8s.ps1
+++ b/scripts/apply-k8s.ps1
@@ -1,0 +1,18 @@
+# Applies namespaces, apps, bootstraps Traefik/TLS, and updates hosts file
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+
+K apply -f k8s\namespaces.yaml
+K apply -f k8s\apps\kali\deployment.yaml
+K apply -f k8s\apps\caldera\deployment.yaml
+K apply -f k8s\apps\dvwa\deployment.yaml
+
+# Bootstrap Traefik LB + TLS and add hosts entries
+pwsh -File scripts\bootstrap-traefik.ps1 -TraefikIP "172.22.10.60"
+Start-Sleep -Seconds 5
+pwsh -File scripts\hosts-add.ps1 -TraefikIP "172.22.10.60"
+
+Write-Host "`nTest URLs:"
+Write-Host "  https://caldera.lab.local  (admin/admin)"
+Write-Host "  https://dvwa.lab.local"
+Write-Host "Portainer (LB): https://portainer.lab.local:9443  (when LB IP appears)"

--- a/scripts/bootstrap-traefik.ps1
+++ b/scripts/bootstrap-traefik.ps1
@@ -1,0 +1,31 @@
+# Sets Traefik to LoadBalancer with a fixed IP, installs wildcard TLS as default
+param(
+  [string]$TraefikIP = "172.22.10.60",
+  [string]$TlsDir = "E:\SOC-9000\artifacts\tls",
+  [string]$Domain = "lab.local"
+)
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+
+# Detect Traefik namespace (k3s default = kube-system)
+$ns = "kube-system"
+try { K -n $ns get deploy traefik | Out-Null } catch { $ns = "traefik"; K -n $ns get deploy traefik | Out-Null }
+
+# Create TLS secret from wildcard cert
+$crt = Join-Path $TlsDir "wildcard.$Domain.crt"
+$key = Join-Path $TlsDir "wildcard.$Domain.key"
+if (!(Test-Path $crt) -or !(Test-Path $key)) { throw "Missing certs in $TlsDir. Run scripts\gen-ssl.ps1 first." }
+
+K -n $ns delete secret wildcard-lab-local-tls --ignore-not-found
+K -n $ns create secret tls wildcard-lab-local-tls --cert="$crt" --key="$key"
+
+# Apply TLSStore pointing to the secret
+K apply -f k8s\ingress\traefik-tlsstore.yaml
+
+# Patch Traefik service to LoadBalancer with fixed IP + MetalLB hint
+K -n $ns patch svc traefik -p @"
+{ "spec": { "type":"LoadBalancer", "loadBalancerIP":"$TraefikIP" },
+  "metadata": { "annotations": { "metallb.universe.tf/loadBalancerIPs":"$TraefikIP" } }
+}
+"@
+Write-Host "Traefik -> LB $TraefikIP ; default TLS set."

--- a/scripts/hosts-add.ps1
+++ b/scripts/hosts-add.ps1
@@ -1,0 +1,25 @@
+# Adds lab hostnames to Windows hosts file.
+param([string]$TraefikIP = "172.22.10.60")
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+
+# Try to get Portainer LB IP (may take a moment after Chunk 3)
+$portainerIP = ""
+try { $portainerIP = K -n portainer get svc portainer -o jsonpath='{.status.loadBalancer.ingress[0].ip}' } catch { }
+
+$entries = @(
+  "$TraefikIP caldera.lab.local",
+  "$TraefikIP dvwa.lab.local"
+)
+if ($portainerIP) { $entries += "$portainerIP portainer.lab.local" }
+
+$hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
+$orig = Get-Content $hosts -ErrorAction Stop
+
+# Remove old SOC-9000 block if present
+$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+$block = @("# SOC-9000 BEGIN") + $entries + @("# SOC-9000 END")
+
+Set-Content -Path $hosts -Value ($filtered + $block) -Force
+Write-Host "Hosts file updated:"
+$block | ForEach-Object { "  $_" | Write-Host }


### PR DESCRIPTION
## Summary
- configure platform namespaces and TLS store for Traefik
- deploy Caldera, DVWA, and Kali CLI workloads
- add bootstrap scripts and documentation for chunk 4 rollout

## Testing
- `yamllint -d '{extends: default, rules: {braces: disable, document-start: disable, commas: disable, colons: disable}}' k8s`
- `pytest`
- `bandit -r scripts`
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path scripts/*.ps1"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6899b1a15954832d9512a0ebbab8c588