### PR TITLE
Add Wazuh deployment overlay and vendor script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ temp/
 # OS cruft
 .DS_Store
 Thumbs.db
+
+# Upstream vendored content
+third_party/

--- a/docs/05-wazuh.md
+++ b/docs/05-wazuh.md
@@ -1,0 +1,24 @@
+# Chunk 5 — Wazuh on k3s
+
+This chunk deploys the Wazuh stack (indexer, manager, dashboard) into namespace `soc`,
+fronted by Traefik with TLS and a friendly hostname.
+
+## Deploy
+```powershell
+pwsh -File .\scripts\wazuh-vendor-and-deploy.ps1
+kubectl get pods -n soc -w
+```
+
+Access
+
+    URL: https://wazuh.lab.local
+
+    Default login: admin / SecretPassword
+
+Notes
+
+    We vendor the official wazuh-kubernetes repo (tag v4.12.0) under third_party/.
+
+    Certificates are generated with the upstream scripts and loaded via secretGenerator.
+
+    Ingress points wazuh.lab.local to Traefik (already LB + TLS from earlier chunks).

--- a/k8s/apps/wazuh/ingress-dashboard.yaml
+++ b/k8s/apps/wazuh/ingress-dashboard.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wazuh-dashboard
+  namespace: soc
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: wazuh.lab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # Upstream creates a Service named 'dashboard' (port 5601)
+                name: dashboard
+                port:
+                  number: 5601

--- a/k8s/apps/wazuh/kustomization.yaml
+++ b/k8s/apps/wazuh/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Deploy Wazuh into the 'soc' namespace
+namespace: soc
+
+# Upstream base (local clone path created by the deploy script)
+resources:
+  - ../../../third_party/wazuh-kubernetes/envs/local-env
+
+# Add our ingress on top
+patchesStrategicMerge:
+  - ingress-dashboard.yaml
+
+# Generate secrets from cert files produced by the deploy script
+secretGenerator:
+  - name: indexer-certs
+    files:
+      - certs/indexer_cluster/root-ca.pem
+      - certs/indexer_cluster/node.pem
+      - certs/indexer_cluster/node-key.pem
+      - certs/indexer_cluster/dashboard.pem
+      - certs/indexer_cluster/dashboard-key.pem
+      - certs/indexer_cluster/admin.pem
+      - certs/indexer_cluster/admin-key.pem
+      - certs/indexer_cluster/filebeat.pem
+      - certs/indexer_cluster/filebeat-key.pem
+    options: { disableNameSuffixHash: true }
+
+  - name: dashboard-certs
+    files:
+      - certs/dashboard_http/cert.pem
+      - certs/dashboard_http/key.pem
+      - certs/indexer_cluster/root-ca.pem
+    options: { disableNameSuffixHash: true }

--- a/scripts/wazuh-vendor-and-deploy.ps1
+++ b/scripts/wazuh-vendor-and-deploy.ps1
@@ -1,0 +1,58 @@
+<#
+Clones upstream Wazuh K8s manifests (v4.12.0) into third_party/,
+generates required certificates via upstream scripts (using WSL),
+creates kustomize secrets, applies the stack, and adds hosts entry.
+
+Prereqs:
+- WSL Ubuntu installed (from earlier chunks)
+- kubectl context points to your k3s on ContainerHost
+- OpenSSL available in WSL (default)
+#>
+
+param(
+  [string]$Ref = "v4.12.0",
+  [string]$VendorDir = "third_party\\wazuh-kubernetes",
+  [string]$OverlayDir = "k8s\\apps\\wazuh",
+  [string]$TraefikIP = "172.22.10.60"
+)
+
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+
+# 1) Vendor upstream
+if (!(Test-Path $VendorDir)) {
+  git clone https://github.com/wazuh/wazuh-kubernetes.git -b $Ref --depth=1 $VendorDir
+  Write-Host "Cloned wazuh-kubernetes@$Ref -> $VendorDir"
+} else {
+  Write-Host "Vendor dir exists, skipping clone."
+}
+
+# 2) Generate certs with upstream scripts in WSL
+$repoWin = (Resolve-Path $VendorDir).Path
+$repoWsl = "/mnt/" + $repoWin.Substring(0,1).ToLower() + $repoWin.Substring(2).Replace('\\','/')
+
+wsl bash -lc "set -euo pipefail; cd '$repoWsl/wazuh/certs/indexer_cluster'; chmod +x generate_certs.sh; ./generate_certs.sh"
+wsl bash -lc "set -euo pipefail; cd '$repoWsl/wazuh/certs/dashboard_http'; chmod +x generate_certs.sh; ./generate_certs.sh"
+
+# 3) Copy certs into our overlay
+$dst1 = Join-Path $OverlayDir "certs\\indexer_cluster"
+$dst2 = Join-Path $OverlayDir "certs\\dashboard_http"
+New-Item -ItemType Directory -Force -Path $dst1 | Out-Null
+New-Item -ItemType Directory -Force -Path $dst2 | Out-Null
+Copy-Item "$VendorDir\\wazuh\\certs\\indexer_cluster\\*.pem" $dst1 -Force
+Copy-Item "$VendorDir\\wazuh\\certs\\dashboard_http\\*.pem" $dst2 -Force
+
+# 4) Apply via kustomize
+kubectl apply -k $OverlayDir
+
+# 5) Add hosts line for wazuh.lab.local -> Traefik IP
+$hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
+$orig = Get-Content $hosts
+$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+$block = @("# SOC-9000 BEGIN",
+           "$TraefikIP wazuh.lab.local",
+           "# SOC-9000 END")
+Set-Content -Path $hosts -Value ($filtered + $block) -Force
+
+Write-Host "`nApplied Wazuh. Watch progress:"
+Write-Host "  kubectl get pods -n soc -w"
+Write-Host "When ready: https://wazuh.lab.local  (default login: admin / SecretPassword)"


### PR DESCRIPTION
## Summary
- ignore vendored `third_party` content
- add Wazuh kustomize overlay and ingress for dashboard
- script to vendor Wazuh manifests, generate certs, and deploy stack
- document Wazuh deployment procedure

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not recognized)*
- `yamllint -d '{extends: default, rules: {braces: disable}}' k8s/apps/wazuh/kustomization.yaml k8s/apps/wazuh/ingress-dashboard.yaml`
- `bandit -r .`

------
https://chatgpt.com/codex/tasks/task_e_6899b657795c832d81558eb38e4aea5b