### PR TITLE
Add TheHive and Cortex deployment

### DIFF
--- a/docs/06-thehive-cortex.md
+++ b/docs/06-thehive-cortex.md
@@ -1,0 +1,30 @@
+# Chunk 6 — TheHive + Cortex on k3s
+
+Installs TheHive and Cortex via Helm, exposes them behind Traefik with TLS,
+and provides RWX storage (NFS provisioner) for Cortex analyzer jobs.
+
+## Apply
+```powershell
+pwsh -File .\scripts\install-rwx-storage.ps1
+pwsh -File .\scripts\install-thehive-cortex.ps1
+pwsh -File .\scripts\storage-defaults-reset.ps1   # optional
+kubectl get pods -n soc -w
+```
+
+URLs
+
+    https://thehive.lab.local
+
+    https://cortex.lab.local
+
+Post-install
+
+    In Cortex, create an admin and an API key.
+
+    In TheHive → Admin → Cortex, add:
+
+        URL: http://cortex.soc.svc:9001
+
+        API key: (the key you created)
+
+    Run a test analyzer from a case/observable.

--- a/k8s/apps/cortex/ingress.yaml
+++ b/k8s/apps/cortex/ingress.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cortex
+  namespace: soc
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: cortex.lab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cortex
+                port:
+                  number: 9001

--- a/k8s/apps/thehive/ingress.yaml
+++ b/k8s/apps/thehive/ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thehive
+  namespace: soc
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: thehive.lab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # We'll install Helm with fullnameOverride=thehive
+                name: thehive
+                port:
+                  number: 9000

--- a/scripts/install-rwx-storage.ps1
+++ b/scripts/install-rwx-storage.ps1
@@ -1,0 +1,22 @@
+# Installs an in-cluster NFS server + provisioner and makes its StorageClass 'rwx' the default.
+param(
+  [string]$Ns = "storage",
+  [string]$Release = "nfs-provisioner",
+  [string]$ScName = "rwx"
+)
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+
+helm repo add nfs-ganesha https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/ | Out-Null
+helm repo update | Out-Null
+
+kubectl get ns $Ns 2>$null | Out-Null; if ($LASTEXITCODE -ne 0) { kubectl create ns $Ns | Out-Null }
+
+helm upgrade --install $Release nfs-ganesha/nfs-server-provisioner `
+  --namespace $Ns `
+  --set persistence.enabled=true `
+  --set persistence.size=20Gi `
+  --set persistence.storageClass=local-path `
+  --set storageClass.name=$ScName `
+  --set storageClass.defaultClass=true
+
+Write-Host "RWX StorageClass '$ScName' installed and set as default."

--- a/scripts/install-thehive-cortex.ps1
+++ b/scripts/install-thehive-cortex.ps1
@@ -1,0 +1,61 @@
+<##
+Installs TheHive and Cortex (Helm), creates Ingresses, and updates hosts.
+Requires: RWX StorageClass available (run scripts\install-rwx-storage.ps1 first).
+##>
+param(
+  [string]$Ns = "soc",
+  [string]$TheHiveRel = "thehive",
+  [string]$CortexRel = "cortex",
+  [string]$TraefikIP = "172.22.10.60"
+)
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+
+# Try both known chart URLs for resilience
+$added = $false
+try { helm repo add strangebee https://strangebee.github.io/helm-charts | Out-Null; $added = $true } catch {}
+if (-not $added) { try { helm repo add strangebee https://strangebeecorp.github.io/helm-charts | Out-Null; $added = $true } catch {} }
+if (-not $added) { throw "Unable to add StrangeBee Helm repo." }
+helm repo update | Out-Null
+
+kubectl get ns $Ns 2>$null | Out-Null; if ($LASTEXITCODE -ne 0) { kubectl create ns $Ns | Out-Null }
+
+# TheHive (chart includes Cassandra, ES, MinIO)
+helm upgrade --install $TheHiveRel strangebee/thehive `
+  --namespace $Ns `
+  --set fullnameOverride=thehive
+
+# Cortex (chart includes its own ES 7.x; needs RWX PVC)
+helm upgrade --install $CortexRel strangebee/cortex `
+  --namespace $Ns `
+  --set fullnameOverride=cortex
+
+Start-Sleep -Seconds 5
+
+# Fallback: find service names by label if they differ
+$thehiveSvc = (K -n $Ns get svc -l "app.kubernetes.io/instance=$TheHiveRel" -o jsonpath="{.items[0].metadata.name}" 2>$null)
+if (-not $thehiveSvc) { $thehiveSvc = "thehive" }
+$cortexSvc  = (K -n $Ns get svc -l "app.kubernetes.io/instance=$CortexRel" -o jsonpath="{.items[0].metadata.name}" 2>$null)
+if (-not $cortexSvc) { $cortexSvc = "cortex" }
+
+# Apply ingresses (patch service names if needed)
+$thIngress = (Get-Content "k8s\apps\thehive\ingress.yaml" -Raw) -replace "name: thehive", "name: $thehiveSvc"
+$cxIngress = (Get-Content "k8s\apps\cortex\ingress.yaml" -Raw) -replace "name: cortex", "name: $cortexSvc"
+$thIngress | K apply -f -
+$cxIngress | K apply -f -
+
+# Hosts entries
+$hostsFile = "$env:SystemRoot\System32\drivers\etc\hosts"
+$orig = Get-Content $hostsFile
+$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+$block = @("# SOC-9000 BEGIN",
+           "$TraefikIP thehive.lab.local",
+           "$TraefikIP cortex.lab.local",
+           "# SOC-9000 END")
+Set-Content -Path $hostsFile -Value ($filtered + $block) -Force
+
+Write-Host "`nDeployed TheHive + Cortex."
+Write-Host "Watch pods:"
+Write-Host "  kubectl get pods -n $Ns -w"
+Write-Host "Open: https://thehive.lab.local , https://cortex.lab.local"
+Write-Host "(When both are running, add Cortex in TheHive under Admin > Cortex.)"

--- a/scripts/storage-defaults-reset.ps1
+++ b/scripts/storage-defaults-reset.ps1
@@ -1,0 +1,5 @@
+# Make 'local-path' default again and keep 'rwx' available.
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+kubectl patch storageclass local-path -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}' 2>$null | Out-Null
+kubectl patch storageclass rwx -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' 2>$null | Out-Null
+Write-Host "Default StorageClass reset to 'local-path'."


### PR DESCRIPTION
## Summary
- add ingress definitions for TheHive and Cortex
- add scripts to install RWX storage, deploy TheHive and Cortex, and reset storageclass defaults
- document TheHive and Cortex installation on k3s

## Testing
- `yamllint k8s/apps/thehive/ingress.yaml k8s/apps/cortex/ingress.yaml`
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `trivy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899baa4f560832dbf5788dbc7dae255