### PR TITLE
Add Nessus deployment for k3s and persistent VM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,6 @@ NESSUS_MODE=docker-first
 SSH_PUBLIC_KEY=C:\Users\%USERNAME%\.ssh\id_ed25519.pub
 ADMIN_USERNAME=labadmin
 ADMIN_PASSWORD=ChangeMe_S0C9000!
-NESSUS_ACTIVATION_CODE=PUT-YOUR-CODE-HERE
 
 # Sizing (VMs)
 RAM_PFSENSE_MB=2048
@@ -77,3 +76,14 @@ PFSENSE_ADMIN_PASS=ChangeMe_S0C9000!
 # k3s
 K3S_CHANNEL=stable
 K3S_VERSION=
+# --- Chunk 7B (Nessus VM) ---
+NESSUS_VM_ENABLED=true
+NESSUS_VM_IP=172.22.20.60
+NESSUS_VM_MAC=00:50:56:9a:20:60
+NESSUS_VM_CPUS=2
+NESSUS_VM_RAM_MB=4096
+NESSUS_DEB=nessus_latest_amd64.deb   # put this .deb in E:\SOC-9000\isos
+# Optional automation (leave blank to finish in the web UI)
+NESSUS_ACTIVATION_CODE=
+NESSUS_ADMIN_USER=nessusadmin
+NESSUS_ADMIN_PASS=ChangeMe_S0C!

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -6,3 +6,6 @@ containerhost ansible_host={{ lookup('env','CH_IP_MGMT') | default('172.22.10.10
 
 [windows]
 victim_win ansible_host=dhcp.please ansible_connection=winrm ansible_user=Administrator ansible_password={{ lookup('env','ADMIN_PASSWORD') | default('ChangeMe_S0C9000!') }} ansible_winrm_transport=basic ansible_winrm_server_cert_validation=ignore
+
+[nessus]
+nessusvm ansible_host={{ lookup('env','NESSUS_VM_IP') | default('172.22.20.60') }} ansible_user={{ lookup('env','ADMIN_USERNAME') | default('labadmin') }}

--- a/ansible/roles/nessus_vm/tasks/main.yml
+++ b/ansible/roles/nessus_vm/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Ensure dependencies
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: true
+
+- name: Copy Nessus .deb from Windows mount (isos dir)
+  vars:
+    deb_name: "{{ lookup('env', 'NESSUS_DEB') | default('nessus_latest_amd64.deb') }}"
+  ansible.builtin.copy:
+    src: "/mnt/e/SOC-9000/isos/{{ deb_name }}"
+    dest: "/tmp/{{ deb_name }}"
+    mode: '0644'
+
+- name: Install Nessus
+  ansible.builtin.apt:
+    deb: "/tmp/{{ lookup('env', 'NESSUS_DEB') | default('nessus_latest_amd64.deb') }}"
+    state: present
+
+- name: Enable & start nessusd
+  ansible.builtin.systemd:
+    name: nessusd
+    enabled: true
+    state: started
+
+- name: Optional register with activation code (if provided)
+  when: lookup('env', 'NESSUS_ACTIVATION_CODE') | default('') | length > 0
+  ansible.builtin.command: /opt/nessus/sbin/nessuscli fetch --register {{ lookup('env', 'NESSUS_ACTIVATION_CODE') }}
+  register: nessus_vm_reg_out
+  changed_when: "'already registered' not in nessus_vm_reg_out.stdout|lower"
+
+- name: Optional create admin user (if both user & pass provided)
+  when: (lookup('env', 'NESSUS_ADMIN_USER') | default('')) | length > 0 and
+        (lookup('env', 'NESSUS_ADMIN_PASS') | default('')) | length > 0
+  ansible.builtin.command: /opt/nessus/sbin/nessuscli adduser "{{ lookup('env', 'NESSUS_ADMIN_USER') }}"
+  args:
+    stdin: |
+      {{ lookup('env', 'NESSUS_ADMIN_PASS') }}
+      {{ lookup('env', 'NESSUS_ADMIN_PASS') }}
+      y
+      y
+      # (accept defaults and grant admin)
+  register: nessus_vm_adduser_out
+  changed_when: "'already exists' not in nessus_vm_adduser_out.stdout|lower"

--- a/ansible/site-nessus.yml
+++ b/ansible/site-nessus.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Nessus on Nessus VM
+  hosts: nessus
+  become: true
+  roles:
+    - nessus_vm

--- a/docs/07-nessus.md
+++ b/docs/07-nessus.md
@@ -1,0 +1,13 @@
+# Chunk 7 — Nessus Essentials on k3s
+
+We run the official Tenable Nessus container in the `soc` namespace and expose it
+via a LoadBalancer at `172.22.10.61:8834` with a hosts entry for `nessus.lab.local`.
+
+## Deploy
+```powershell
+pwsh -File .\scripts\deploy-nessus-essentials.ps1
+kubectl -n soc get pods -w
+```
+
+Open https://nessus.lab.local:8834, select Nessus Essentials, enter/obtain an
+activation code, and create the admin user.

--- a/docs/07B-nessus-vm.md
+++ b/docs/07B-nessus-vm.md
@@ -1,0 +1,30 @@
+# Chunk 7B — Nessus VM (persistent)
+
+Builds an Ubuntu 22.04 VM, installs Nessus from the `.deb`, and keeps data across reboots.
+
+## Prereqs
+- `E:\SOC-9000\isos\ubuntu-22.04.iso`
+- `E:\SOC-9000\isos\nessus_latest_amd64.deb`  (or adjust `NESSUS_DEB` in `.env`)
+
+## Config
+Update `.env` (defaults shown):
+
+NESSUS_VM_IP=172.22.20.60
+NESSUS_VM_CPUS=2
+NESSUS_VM_RAM_MB=4096
+NESSUS_DEB=nessus_latest_amd64.deb
+NESSUS_ACTIVATION_CODE= # optional; leave blank to activate in UI
+NESSUS_ADMIN_USER=nessusadmin
+NESSUS_ADMIN_PASS=ChangeMe_S0C!
+
+## Build & configure
+```powershell
+pwsh -File .\scripts\nessus-vm-build-and-config.ps1
+```
+
+Access
+
+    URL: https://nessus.lab.local:8834
+
+    If NESSUS_ACTIVATION_CODE is set, the role attempts auto-registration.
+    Otherwise, finish in the web UI and create the admin user.

--- a/k8s/apps/nessus/deployment.yaml
+++ b/k8s/apps/nessus/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nessus
+  namespace: soc
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: nessus } }
+  template:
+    metadata: { labels: { app: nessus } }
+    spec:
+      containers:
+        - name: nessus
+          image: tenable/nessus:latest-ubuntu
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8834
+          readinessProbe:
+            httpGet: { path: /, port: 8834, scheme: HTTPS }
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /, port: 8834, scheme: HTTPS }
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          # IMPORTANT: Tenable's container doesn't support data volumes.
+          # Treat this as ephemeral for lab use.

--- a/k8s/apps/nessus/service.yaml
+++ b/k8s/apps/nessus/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nessus
+  namespace: soc
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: "172.22.10.61"
+spec:
+  type: LoadBalancer
+  selector: { app: nessus }
+  ports:
+    - name: https
+      port: 8834
+      targetPort: 8834
+  loadBalancerIP: 172.22.10.61

--- a/packer/nessus-vm/http/meta-data
+++ b/packer/nessus-vm/http/meta-data
@@ -1,0 +1,2 @@
+instance-id: nessus
+local-hostname: nessus

--- a/packer/nessus-vm/http/netplan.tmpl
+++ b/packer/nessus-vm/http/netplan.tmpl
@@ -1,0 +1,10 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ens160:
+      dhcp4: false
+      addresses: [${ip_addr}/24]
+      gateway4: ${ip_gw}
+      nameservers:
+        addresses: [${ip_dns}]

--- a/packer/nessus-vm/http/user-data
+++ b/packer/nessus-vm/http/user-data
@@ -1,0 +1,22 @@
+#cloud-config
+autoinstall:
+  version: 1
+  locale: en_US
+  keyboard: { layout: us }
+  identity:
+    hostname: nessus
+    username: labadmin
+    password: "ChangeMe_S0C9000!"
+  ssh:
+    install-server: true
+  packages:
+    - openssh-server
+    - open-vm-tools
+    - qemu-guest-agent
+    - curl
+    - ca-certificates
+    - net-tools
+  storage:
+    layout: { name: direct }
+  late-commands:
+    - curtin in-target --target=/target -- systemctl enable qemu-guest-agent || true

--- a/packer/nessus-vm/nessus.pkr.hcl
+++ b/packer/nessus-vm/nessus.pkr.hcl
@@ -1,0 +1,73 @@
+packer {
+  required_plugins {
+    vmware = {
+      source  = "github.com/hashicorp/vmware"
+      version = ">= 1.1.1"
+    }
+  }
+}
+
+variable "iso_path"      { type = string, default = "E:/SOC-9000/isos/ubuntu-22.04.iso" }
+variable "vm_name"       { type = string, default = "nessus-vm" }
+variable "cpus"          { type = number, default = 2 }
+variable "memory_mb"     { type = number, default = 4096 }
+variable "disk_size_mb"  { type = number, default = 60000 }
+variable "ssh_username"  { type = string, default = "labadmin" }
+variable "ssh_password"  { type = string, default = "ChangeMe_S0C9000!" }
+variable "vmnet"         { type = string, default = "VMnet21" }            # SOC
+variable "ip_addr"       { type = string, default = "172.22.20.60" }
+variable "ip_gw"         { type = string, default = "172.22.20.1" }
+variable "ip_dns"        { type = string, default = "172.22.20.1" }
+
+source "vmware-iso" "ubuntu2204" {
+  vm_name              = var.vm_name
+  iso_url              = var.iso_path
+  iso_checksum         = "none"
+
+  headless             = true
+  http_directory       = "${path.root}/http"
+
+  communicator         = "ssh"
+  ssh_username         = var.ssh_username
+  ssh_password         = var.ssh_password
+  ssh_timeout          = "40m"
+
+  cpus                 = var.cpus
+  memory               = var.memory_mb
+  disk_size            = var.disk_size_mb
+  network_adapter_type = "vmxnet3"
+  network              = var.vmnet
+
+  boot_wait            = "5s"
+  boot_command = [
+    "<esc><esc><enter><wait>",
+    "/casper/vmlinuz ",
+    "autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
+    "initrd=/casper/initrd ",
+    "-- <enter>"
+  ]
+
+  shutdown_command = "echo '${var.ssh_password}' | sudo -S shutdown -P now"
+}
+
+build {
+  sources = ["source.vmware-iso.ubuntu2204"]
+
+  provisioner "shell" {
+    script = "${path.root}/scripts/postinstall.sh"
+  }
+
+  # Render netplan with static IP
+  provisioner "file" {
+    destination = "/home/${var.ssh_username}/50-soc-nessus.yaml"
+    content     = templatefile("${path.root}/http/netplan.tmpl", {
+      ip_addr = var.ip_addr, ip_gw = var.ip_gw, ip_dns = var.ip_dns
+    })
+  }
+  provisioner "shell" {
+    inline = [
+      "echo '${var.ssh_password}' | sudo -S mv /home/${var.ssh_username}/50-soc-nessus.yaml /etc/netplan/50-soc-nessus.yaml",
+      "echo '${var.ssh_password}' | sudo -S netplan apply"
+    ]
+  }
+}

--- a/packer/nessus-vm/scripts/postinstall.sh
+++ b/packer/nessus-vm/scripts/postinstall.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+echo "labadmin ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/99-labadmin >/dev/null
+sudo apt-get update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y
+sudo timedatectl set-timezone Europe/Zurich || true
+sudo systemctl enable --now ssh
+sudo sed -i 's/^#\?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+sudo systemctl restart ssh
+sudo touch /etc/soc-9000.nessus.built

--- a/scripts/deploy-nessus-essentials.ps1
+++ b/scripts/deploy-nessus-essentials.ps1
@@ -1,0 +1,41 @@
+# Deploy Nessus Essentials on k3s and add a hosts entry.
+param(
+  [string]$Ns = "soc",
+  [string]$LbIp = "172.22.10.61",
+  [string]$Host = "nessus.lab.local"
+)
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+
+# Ensure namespace exists
+K get ns $Ns 2>$null | Out-Null; if ($LASTEXITCODE -ne 0) { K create ns $Ns | Out-Null }
+
+# Apply manifests
+K apply -f k8s\apps\nessus\deployment.yaml
+# Inject the LB IP annotation/value (in case you change it later)
+$svc = (Get-Content "k8s\apps\nessus\service.yaml" -Raw) -replace '172\.22\.10\.61', $LbIp
+$svc | K apply -f -
+
+# Wait for external IP
+Write-Host "Waiting for LoadBalancer IP..."
+$ip = ""
+for ($i=0; $i -lt 60; $i++) {
+  $ip = K -n $Ns get svc nessus -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
+  if ($ip) { break }
+  Start-Sleep -Seconds 2
+}
+if (-not $ip) { $ip = $LbIp }
+
+# Update hosts
+$hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
+$orig = Get-Content $hosts
+$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+$block = @("# SOC-9000 BEGIN", "$ip $Host", "# SOC-9000 END")
+Set-Content -Path $hosts -Value ($filtered + $block) -Force
+
+Write-Host "`nOpen: https://$Host:8834"
+Write-Host "Setup steps:"
+Write-Host "  1) Choose 'Nessus Essentials', request/enter activation code."
+Write-Host "  2) Create the admin account."
+Write-Host "  3) Start a basic scan against the VICTIM segment (172.22.30.0/24)."
+Write-Host "`nNote: Container is ephemeral—if the pod is recreated, you'll re-enter activation/admin."

--- a/scripts/nessus-vm-build-and-config.ps1
+++ b/scripts/nessus-vm-build-and-config.ps1
@@ -1,0 +1,37 @@
+# Builds the Nessus VM with Packer, runs the Ansible role, and adds a hosts entry.
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+
+# Load .env
+if (!(Test-Path ".env")) { throw ".env not found. Run 'make init' first." }
+(Get-Content ".env" | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
+  if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+}
+
+# Build with Packer
+pushd packer\nessus-vm
+packer init .
+packer build -force -var "vmnet=$env:VMNET_SOC" -var "ip_addr=$env:NESSUS_VM_IP" -var "ip_gw=$env:PFSENSE_SOC_IP" -var "ip_dns=$env:PFSENSE_SOC_IP" `
+  -var "cpus=$env:NESSUS_VM_CPUS" -var "memory_mb=$env:NESSUS_VM_RAM_MB" .
+popd
+
+# Start VM
+$vmx = Join-Path $env:ARTIFACTS_DIR "nessus-vm\nessus-vm.vmx"
+$vmrun = @("C:\Program Files (x86)\VMware\VMware Workstation\vmrun.exe","C:\Program Files\VMware\VMware Workstation\vmrun.exe") | ? { Test-Path $_ } | Select-Object -First 1
+if (-not $vmrun) { throw "vmrun not found" }
+& $vmrun -T ws start $vmx nogui | Out-Null
+
+# Run Ansible role from WSL (uses /mnt/e path to copy .deb)
+$inv = "/mnt/e/SOC-9000/SOC-9000/ansible/inventory.ini"
+$play= "/mnt/e/SOC-9000/SOC-9000/ansible/site-nessus.yml"
+wsl bash -lc "ansible-playbook -i '$inv' '$play'"
+
+# Add hosts mapping for convenience
+$hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
+$orig = Get-Content $hosts
+$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+$block = @("# SOC-9000 BEGIN", "$($env:NESSUS_VM_IP) nessus.lab.local", "# SOC-9000 END")
+Set-Content -Path $hosts -Value ($filtered + $block) -Force
+
+Write-Host "`nDone. Open: https://nessus.lab.local:8834"
+Write-Host "If you didn't pre-set NESSUS_ACTIVATION_CODE, complete activation in the UI."


### PR DESCRIPTION
## Summary
- deploy Tenable Nessus Essentials on k3s via new manifests and helper script
- add persistent Nessus VM with Packer build, Ansible role and automation script
- document usage and extend env example for new VM settings

## Testing
- `yamllint -d "{rules: {document-start: disable, line-length: {max: 120}, braces: disable, brackets: disable, comments-indentation: disable, comments: disable, truthy: disable}}" k8s/apps/nessus/deployment.yaml k8s/apps/nessus/service.yaml ansible/site-nessus.yml ansible/roles/nessus_vm/tasks/main.yml packer/nessus-vm/http/user-data` (no output)
- `ansible-lint ansible/site-nessus.yml`
- `bandit -r .`
- `pytest`
- `trivy fs --scanners vuln,misconfig .`

------
https://chatgpt.com/codex/tasks/task_e_6899c3ab9878832dbc316ea8e8dd3c85