### PR TITLE
Add telemetry automation for Wazuh, Atomic Red Team, and CALDERA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,8 @@ NESSUS_DEB=nessus_latest_amd64.deb   # put this .deb in E:\SOC-9000\isos
 NESSUS_ACTIVATION_CODE=
 NESSUS_ADMIN_USER=nessusadmin
 NESSUS_ADMIN_PASS=ChangeMe_S0C!
+# --- Chunk 8 ---
+WAZUH_MANAGER_LB_IP=172.22.10.62
+PFSENSE_SYSLOG_TARGET=172.22.10.10    # ContainerHost (MGMT)
+WINDOWS_VICTIM_IP=172.22.30.100       # set to your Win VM's IP (DHCP reservation or static)
+WAZUH_AGENT_MSI_URL=https://packages.wazuh.com/4.x/windows/wazuh-agent-4.7.5-1.msi

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -5,7 +5,7 @@ pfsense ansible_host=172.22.10.1 ansible_user={{ lookup('env','PFSENSE_ADMIN_USE
 containerhost ansible_host={{ lookup('env','CH_IP_MGMT') | default('172.22.10.10') }} ansible_user={{ lookup('env','ADMIN_USERNAME') | default('labadmin') }}
 
 [windows]
-victim_win ansible_host=dhcp.please ansible_connection=winrm ansible_user=Administrator ansible_password={{ lookup('env','ADMIN_PASSWORD') | default('ChangeMe_S0C9000!') }} ansible_winrm_transport=basic ansible_winrm_server_cert_validation=ignore
+victim_win ansible_host={{ lookup('env','WINDOWS_VICTIM_IP') | default('172.22.30.100') }} ansible_connection=winrm ansible_user=Administrator ansible_password={{ lookup('env','ADMIN_PASSWORD') | default('ChangeMe_S0C9000!') }} ansible_winrm_transport=basic ansible_winrm_server_cert_validation=ignore
 
 [nessus]
 nessusvm ansible_host={{ lookup('env','NESSUS_VM_IP') | default('172.22.20.60') }} ansible_user={{ lookup('env','ADMIN_USERNAME') | default('labadmin') }}

--- a/ansible/roles/containerhost_rsyslog/tasks/main.yml
+++ b/ansible/roles/containerhost_rsyslog/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Ensure rsyslog installed and enabled
+  become: yes
+  apt:
+    name: rsyslog
+    state: present
+    update_cache: yes
+
+- name: Create pfsense log dir
+  become: yes
+  file:
+    path: /var/log/pfsense
+    state: directory
+    mode: '0755'
+
+- name: Configure rsyslog listener for pfSense on MGMT IP
+  become: yes
+  copy:
+    dest: /etc/rsyslog.d/10-pfsense.conf
+    mode: '0644'
+    content: |
+      module(load="imudp")
+      input(type="imudp" port="514" address="{{ lookup('env','CH_IP_MGMT') | default('172.22.10.10') }}")
+      template(name="PFLine" type="string" string="%msg%\n")
+      if ($fromhost-ip == "{{ lookup('env','PFSENSE_MGMT_IP') | default('172.22.10.1') }}") then {
+        action(type="omfile" file="/var/log/pfsense/pfsense.log" template="PFLine")
+        stop
+      }
+
+- name: Restart rsyslog
+  become: yes
+  service: { name: rsyslog, state: restarted, enabled: yes }

--- a/ansible/roles/containerhost_wazuh_agent/tasks/main.yml
+++ b/ansible/roles/containerhost_wazuh_agent/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Add Wazuh APT repo
+  become: yes
+  shell: |
+    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --dearmor | tee /usr/share/keyrings/wazuh.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee /etc/apt/sources.list.d/wazuh.list
+  args: { creates: /etc/apt/sources.list.d/wazuh.list }
+
+- name: Install wazuh-agent
+  become: yes
+  apt: { name: wazuh-agent, state: present, update_cache: yes }
+
+- name: Configure manager address
+  become: yes
+  replace:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<address>.*</address>'
+    replace: '<address>{{ lookup("env","WAZUH_MANAGER_LB_IP") | default("172.22.10.62") }}</address>'
+
+- name: Ensure localfile for pfSense logs
+  become: yes
+  blockinfile:
+    path: /var/ossec/etc/ossec.conf
+    marker: "<!-- PF-SOC-9000 {mark} -->"
+    block: |
+      <localfile>
+        <log_format>syslog</log_format>
+        <location>/var/log/pfsense/pfsense.log</location>
+      </localfile>
+
+- name: Enable & restart agent
+  become: yes
+  service: { name: wazuh-agent, state: restarted, enabled: yes }

--- a/ansible/roles/pfsense_restore/files/config.xml.j2
+++ b/ansible/roles/pfsense_restore/files/config.xml.j2
@@ -24,4 +24,13 @@
     <rule><type>pass</type><interface>opt2</interface><ipprotocol>inet</ipprotocol><protocol>any</protocol><descr>VICTIM any</descr><source><network>opt2</network></source><destination><any/></destination></rule>
     <rule><type>pass</type><interface>opt3</interface><ipprotocol>inet</ipprotocol><protocol>any</protocol><descr>RED any</descr><source><network>opt3</network></source><destination><any/></destination></rule>
   </filter>
+  <syslog>
+    <remoteserver>
+      <ip>{{ syslog_target | default('172.22.10.10') }}</ip>
+      <transport>udp</transport>
+      <port>514</port>
+      <level>info</level>
+      <enabled>on</enabled>
+    </remoteserver>
+  </syslog>
 </config>

--- a/ansible/roles/pfsense_syslog/tasks/main.yml
+++ b/ansible/roles/pfsense_syslog/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Render config.xml with syslog target (reusing main template but adding syslog)
+  ansible.builtin.template:
+    src: ../pfsense_restore/files/config.xml.j2
+    dest: /root/config.xml
+    mode: '0600'
+  vars:
+    syslog_target: "{{ lookup('env','PFSENSE_SYSLOG_TARGET') | default('172.22.10.10') }}"
+
+- name: Inject syslog settings via pfSsh.php restore
+  ansible.builtin.shell: |
+    cat >/root/restore.php <<'PHP'
+    <?php
+    require_once("util.inc");
+    global $config;
+    // Add/overwrite syslog remote target
+    $config['syslog']['remoteserver'][] = array(
+      'ip' => '{{ syslog_target }}',
+      'transport' => 'udp',
+      'port' => '514',
+      'level' => 'info',
+      'enabled' => 'on'
+    );
+    write_config("Set remote syslog target for SOC-9000");
+    ?>
+    PHP
+    php -d display_errors=1 /root/restore.php
+  args: { executable: /bin/sh }
+
+- name: Restart syslog service
+  ansible.builtin.shell: /usr/local/sbin/pfSsh.php playback svc restart syslog

--- a/ansible/roles/windows_atomic/tasks/main.yml
+++ b/ansible/roles/windows_atomic/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure NuGet provider & PowerShellGet
+  win_shell: |
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+    Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
+
+- name: Install Invoke-AtomicRedTeam module
+  win_shell: Install-Module -Name Invoke-AtomicRedTeam -Force -Scope AllUsers
+
+- name: Initialize Atomic Red Team (download atomics)
+  win_shell: |
+    Import-Module Invoke-AtomicRedTeam
+    Initialize-AtomicRedTeam
+
+- name: Run a SAFE sample Atomic set (creates & deletes temp files, benign commands)
+  win_shell: |
+    Import-Module Invoke-AtomicRedTeam
+    # Example benign-ish tests; if a test fails due to deps, it will be skipped
+    Invoke-AtomicTest T1059.003 -TestNumbers 1 -Cleanup
+    Invoke-AtomicTest T1112 -TestNumbers 1 -Cleanup
+    Invoke-AtomicTest T1033 -TestNumbers 1 -Cleanup

--- a/ansible/roles/windows_caldera/tasks/main.yml
+++ b/ansible/roles/windows_caldera/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Download CALDERA Sandcat (Windows x64)
+  win_shell: |
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $url = "https://caldera.lab.local/file/download?platform=windows&arch=amd64"
+    Invoke-WebRequest -Uri $url -OutFile C:\\Windows\\Temp\\sandcat.exe -UseBasicParsing
+  args: { executable: powershell.exe }
+
+- name: Run agent (bypass TLS validation; lab cert)
+  win_shell: |
+    Start-Process -FilePath "C:\\Windows\\Temp\\sandcat.exe" -ArgumentList "-server https://caldera.lab.local -group SOC-9000 -v" -WindowStyle Hidden
+  args: { executable: powershell.exe }

--- a/ansible/roles/windows_wazuh_agent/tasks/main.yml
+++ b/ansible/roles/windows_wazuh_agent/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Download Wazuh agent MSI
+  win_get_url:
+    url: "{{ lookup('env','WAZUH_AGENT_MSI_URL') | default('https://packages.wazuh.com/4.x/windows/wazuh-agent-4.7.5-1.msi') }}"
+    dest: C:\\Windows\\Temp\\wazuh-agent.msi
+
+- name: Install Wazuh agent (point to manager LB)
+  win_package:
+    path: C:\\Windows\\Temp\\wazuh-agent.msi
+    product_id: '{00000000-0000-0000-0000-0000WAZUHAGT}'
+    arguments: WAZUH_MANAGER="{{ lookup('env','WAZUH_MANAGER_LB_IP') | default('172.22.10.62') }}" WAZUH_REGISTRATION_SERVER="{{ lookup('env','WAZUH_MANAGER_LB_IP') | default('172.22.10.62') }}"
+    state: present
+
+- name: Start Wazuh agent
+  win_service:
+    name: WazuhSvc
+    start_mode: auto
+    state: started

--- a/ansible/site-telemetry.yml
+++ b/ansible/site-telemetry.yml
@@ -1,0 +1,14 @@
+---
+- name: pfSense -> remote syslog
+  hosts: pfsense
+  gather_facts: no
+  roles: [ pfsense_syslog ]
+
+- name: ContainerHost rsyslog + wazuh-agent
+  hosts: containerhost
+  become: yes
+  roles: [ containerhost_rsyslog, containerhost_wazuh_agent ]
+
+- name: 'Windows victim: wazuh-agent + atomic + caldera'
+  hosts: windows
+  roles: [ windows_wazuh_agent, windows_atomic, windows_caldera ]

--- a/docs/08-atomic-caldera-wazuh.md
+++ b/docs/08-atomic-caldera-wazuh.md
@@ -1,0 +1,32 @@
+# Chunk 8 — Atomic Red Team, CALDERA, and pfSense → Wazuh
+
+This chunk wires blue-team telemetry and gives you ready red-team signals.
+
+## Steps
+```powershell
+# 1) Expose Wazuh manager for agents
+pwsh -File .\scripts\expose-wazuh-manager.ps1
+
+# 2) Set WINDOWS_VICTIM_IP in .env
+# 3) Bootstrap telemetry, agents, Atomic, CALDERA
+pwsh -File .\scripts\telemetry-bootstrap.ps1
+```
+
+What it does
+
+    pfSense → ContainerHost (rsyslog) → Wazuh using the Wazuh agent on the ContainerHost.
+
+    Windows Victim → Wazuh via the Windows agent.
+
+    Atomic Red Team runs a handful of safe tests (with cleanup).
+
+    CALDERA Sandcat agent installs and phones home; run a small operation from the UI if desired.
+
+URLs
+
+    Wazuh: https://wazuh.lab.local
+
+    CALDERA: https://caldera.lab.local
+
+    Notes: Nessus (Chunk 7/7B) remains available at https://nessus.lab.local:8834. If your pfSense UI or CALDERA agent paths differ, adjust the role URLs accordingly.
+

--- a/scripts/expose-wazuh-manager.ps1
+++ b/scripts/expose-wazuh-manager.ps1
@@ -1,0 +1,46 @@
+# Expose wazuh-manager via MetalLB (1514/1515 TCP). Auto-detects selector labels.
+param([string]$Ns="soc",[string]$LbIp="172.22.10.62")
+$ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$a) kubectl @a }
+
+if (Test-Path ".env") {
+  (Get-Content .env | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
+    if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+  }
+  if ($env:WAZUH_MANAGER_LB_IP) { $LbIp = $env:WAZUH_MANAGER_LB_IP }
+}
+
+# Find a wazuh-manager pod and reuse its labels as selector
+$pod = K -n $Ns get pods -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.labels}{"\n"}{end}' `
+  | Select-String -Pattern "wazuh.*manager" | Select-Object -First 1
+if (!$pod) { throw "Could not find wazuh manager pod labels. Is Wazuh deployed in $Ns?" }
+
+$labelJson = $pod.ToString().Split("|")[1] | ConvertFrom-Json
+$selectorPairs = $labelJson.PSObject.Properties | Where-Object { $_.Name -match 'app|app\.kubernetes\.io|component' } |
+  ForEach-Object { '"'+$_.Name+'": "'+$_.Value+'"' } -join ", "
+
+$svc = @"
+apiVersion: v1
+kind: Service
+metadata:
+  name: wazuh-manager-lb
+  namespace: $Ns
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: "$LbIp"
+spec:
+  type: LoadBalancer
+  selector: { $selectorPairs }
+  ports:
+    - name: agent-data
+      protocol: TCP
+      port: 1514
+      targetPort: 1514
+    - name: agent-auth
+      protocol: TCP
+      port: 1515
+      targetPort: 1515
+  loadBalancerIP: $LbIp
+"@
+$svc | K apply -f -
+Write-Host "Exposed wazuh-manager on $LbIp (1514/1515)."
+

--- a/scripts/telemetry-bootstrap.ps1
+++ b/scripts/telemetry-bootstrap.ps1
@@ -1,0 +1,11 @@
+# 1) Expose Wazuh Manager for agents
+pwsh -File .\scripts\expose-wazuh-manager.ps1
+
+# 2) Run Ansible play to wire syslog, agents, atomic, caldera
+$inv = "/mnt/e/SOC-9000/SOC-9000/ansible/inventory.ini"
+$play= "/mnt/e/SOC-9000/SOC-9000/ansible/site-telemetry.yml"
+wsl bash -lc "ansible-playbook -i '$inv' '$play'"
+
+Write-Host "`nTelemetry bootstrap kicked off."
+Write-Host "Check Wazuh manager agents: https://wazuh.lab.local (Agents tab)."
+


### PR DESCRIPTION
## Summary
- route pfSense logs to Wazuh via rsyslog and agent
- deploy Wazuh agent, Atomic Red Team, and CALDERA Sandcat on Windows
- provide bootstrap scripts and telemetry playbook

## Testing
- `pytest` *(no tests found)*
- `ansible-lint ansible/site-telemetry.yml` *(fails: missing ansible.windows modules and style issues)*
- `yamllint ansible` *(fails: multiple style violations across repo)*
- `bandit -r .`
- `ansible-galaxy collection install ansible.windows` *(fails: 403 Forbidden)*
- `pwsh -NoLogo -NoProfile -Command "Install-Module PSScriptAnalyzer -Force"` *(pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6899c61e9854832d9a83b1bab3a48fca