### PR TITLE
Add backup and reset utilities with smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,7 @@ WAZUH_MANAGER_LB_IP=172.22.10.62
 PFSENSE_SYSLOG_TARGET=172.22.10.10    # ContainerHost (MGMT)
 WINDOWS_VICTIM_IP=172.22.30.100       # set to your Win VM's IP (DHCP reservation or static)
 WAZUH_AGENT_MSI_URL=https://packages.wazuh.com/4.x/windows/wazuh-agent-4.7.5-1.msi
+
+# --- Chunk 10 (QoL) ---
+BACKUP_DIR=E:\SOC-9000\backups
+SNAPSHOT_RETENTION=5

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,35 @@
 SHELL := pwsh
 
 help:
-@Write-Host "Targets: init, env, check, up-all, down-all, status"
+	@Write-Host "Targets: init, env, check, up-all, down-all, status"
 
 init:
-@Copy-Item .env.example .env -Force
-@Write-Host "Edit .env before continuing."
+	@Copy-Item .env.example .env -Force
+	@Write-Host "Edit .env before continuing."
 
 env:
-@Get-Content .env | ? {$_ -and $_ -notmatch '^\s*#'}
+	@Get-Content .env | ? {$_ -and $_ -notmatch ^\s*#}
 
 check:
-@pwsh -NoProfile -ExecutionPolicy Bypass -File orchestration/up.ps1 -CheckOnly
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File orchestration/up.ps1 -CheckOnly
 
 up-all:
-@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/lab-up.ps1
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/lab-up.ps1
 
 down-all:
-@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/lab-down.ps1
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/lab-down.ps1
 
 status:
-@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/lab-status.ps1
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/lab-status.ps1
+
+backup:
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/backup-run.ps1
+
+reset:
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/reset-lab.ps1
+
+reset-hard:
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/reset-lab.ps1 -Hard
+
+smoke:
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/smoke-test.ps1

--- a/ansible/site-backup.yml
+++ b/ansible/site-backup.yml
@@ -1,0 +1,48 @@
+---
+- name: SOC-9000 snapshot on ContainerHost
+  hosts: containerhost
+  become: true
+  vars:
+    out_dir: "/tmp/soc-9000-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.time | regex_replace(':','') }}"
+  tasks:
+    - name: Create temp backup dir
+      ansible.builtin.file:
+        path: "{{ out_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Save cluster info (without secret data)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        kubectl version --output=yaml > {{ out_dir }}/cluster-version.yaml
+        kubectl get ns -o yaml > {{ out_dir }}/namespaces.yaml
+        kubectl get all,ingress,svc,cm,pvc,pv,deploy,ds,sts,job,cronjob -A -o yaml > {{ out_dir }}/resources.yaml
+        kubectl get secret -A -o json | jq '{items:[.items[]|{ns:.metadata.namespace,name:.metadata.name,type:.type}]}' > {{ out_dir }}/secrets-list.json
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: Archive PV data (local-path + optional NFS)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        cd /
+        tar -czf {{ out_dir }}/cluster-storage.tgz \
+          var/lib/rancher/k3s/storage \
+          srv/nfs 2>/dev/null || true
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: Fetch snapshot to Windows backup folder
+      vars:
+        dest_root: "/mnt/e/SOC-9000/backups"
+      ansible.builtin.fetch:
+        src: "{{ item }}"
+        dest: "{{ dest_root }}/"
+        flat: false
+      with_items:
+        - "{{ out_dir }}/cluster-version.yaml"
+        - "{{ out_dir }}/namespaces.yaml"
+        - "{{ out_dir }}/resources.yaml"
+        - "{{ out_dir }}/secrets-list.json"
+        - "{{ out_dir }}/cluster-storage.tgz"

--- a/docs/10-backup-reset.md
+++ b/docs/10-backup-reset.md
@@ -1,0 +1,39 @@
+# Chunk 10 — Backups, Reset & Smoke Test
+
+## Backup
+```powershell
+pwsh -File .\scripts\backup-run.ps1
+
+Creates a timestamped ZIP in BACKUP_DIR (default E:\SOC-9000\backups), trims old files per SNAPSHOT_RETENTION.
+
+What’s inside
+
+    cluster-version.yaml, namespaces.yaml, resources.yaml
+
+    secrets-list.json (names/types only)
+
+    cluster-storage.tgz (PV data from local-path and NFS, if present)
+
+    Restore note (lab-level): bring the cluster back with make up-all, then you can
+    review resources.yaml to re-apply deltas, and extract PV files from cluster-storage.tgz
+    to repopulate data on the ContainerHost if needed.
+```
+
+## Reset
+
+```powershell
+# Soft reset: purge app namespaces, re-apply workloads
+pwsh -File .\scripts\reset-lab.ps1
+
+# Hard reset (also wipes PV data on ContainerHost)
+pwsh -File .\scripts\reset-lab.ps1 -Hard
+```
+
+## Smoke Test
+
+```powershell
+pwsh -File .\scripts\smoke-test.ps1
+```
+
+Shows quick reachability for the main URLs.
+

--- a/scripts/backup-run.ps1
+++ b/scripts/backup-run.ps1
@@ -1,0 +1,32 @@
+# Creates a timestamped backup under BACKUP_DIR; trims old snapshots.
+$ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
+
+# Load env
+if (Test-Path ".env") {
+  (Get-Content ".env" | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
+    if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+  }
+}
+$backupDir = $env:BACKUP_DIR; if(-not $backupDir){ $backupDir="E:\\SOC-9000\\backups" }
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$out = Join-Path $backupDir "SOC-9000-$stamp"
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+# Run the Ansible snapshot (WSL)
+$inv = "/mnt/e/SOC-9000/SOC-9000/ansible/inventory.ini"
+$play= "/mnt/e/SOC-9000/SOC-9000/ansible/site-backup.yml"
+wsl bash -lc "ansible-playbook -i '$inv' '$play'"
+
+# Move fetched files into the right timestamped folder and zip them
+# (Ansible 'fetch' created nested dirs; collect them)
+Get-ChildItem -Path (Join-Path $backupDir "SOC-9000") -Recurse -File | % { Copy-Item $_.FullName $out -Force }
+Compress-Archive -Path (Join-Path $out "*") -DestinationPath (Join-Path $backupDir "SOC-9000-$stamp.zip")
+Remove-Item $out -Recurse -Force
+
+# Retention
+$ret = [int]($env:SNAPSHOT_RETENTION ?? "5")
+$zips = Get-ChildItem $backupDir -Filter "SOC-9000-*.zip" | Sort-Object LastWriteTime -Descending
+if ($zips.Count -gt $ret) { $zips[$ret..($zips.Count-1)] | Remove-Item -Force }
+
+Write-Host "Backup written: $(Join-Path $backupDir "SOC-9000-$stamp.zip")"
+

--- a/scripts/reset-lab.ps1
+++ b/scripts/reset-lab.ps1
@@ -1,0 +1,51 @@
+<##
+Soft reset: delete app namespaces and PVCs, then re-apply core apps.
+Hard reset (-Hard): also wipes PV data on ContainerHost (local-path & NFS).
+#>
+param([switch]$Hard = $false)
+$ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
+function K { param([Parameter(ValueFromRemainingArguments)]$a) kubectl @a }
+
+$ns = @("soc","victim","red","portainer")
+Write-Host "Deleting namespaces (this may take a minute)..." -ForegroundColor Yellow
+foreach($n in $ns){ try { K delete ns $n --ignore-not-found --wait=true } catch{} }
+
+# Recreate namespaces (empty)
+K apply -f k8s\namespaces.yaml
+
+if ($Hard) {
+  Write-Host "Wiping PV data on ContainerHost (HARD)..." -ForegroundColor Red
+  # SSH via WSL to ContainerHost and wipe storage paths
+  # Load .env for CH_IP_MGMT
+  if (Test-Path ".env") {
+    (Get-Content ".env" | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
+      if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+    }
+  }
+  $host = $env:CH_IP_MGMT; if(-not $host){ $host="172.22.10.10" }
+  wsl bash -lc "ssh -o StrictHostKeyChecking=no labadmin@$host 'sudo rm -rf /var/lib/rancher/k3s/storage/* /srv/nfs/* 2>/dev/null || true'"
+}
+
+Write-Host "Re-applying platform & apps..."
+pwsh -File scripts\apply-k8s.ps1
+pwsh -File scripts\wazuh-vendor-and-deploy.ps1
+pwsh -File scripts\install-rwx-storage.ps1
+pwsh -File scripts\install-thehive-cortex.ps1
+pwsh -File scripts\storage-defaults-reset.ps1
+
+# Nessus (respect your mode)
+$envBlock = Get-Content .env | ? {$_ -and $_ -notmatch '^\s*#'}
+$mode = ($envBlock | ? { $_ -match '^NESSUS_MODE=' }) -replace '^NESSUS_MODE=',''
+if (!$mode) { $mode = "docker-first" }
+if ($mode -eq "docker-first") {
+  pwsh -File scripts\deploy-nessus-essentials.ps1
+} else {
+  pwsh -File scripts\nessus-vm-build-and-config.ps1
+}
+
+pwsh -File scripts\expose-wazuh-manager.ps1
+pwsh -File scripts\telemetry-bootstrap.ps1
+pwsh -File scripts\hosts-refresh.ps1
+
+Write-Host "Reset complete."
+

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -1,0 +1,24 @@
+# Basic reachability check for lab URLs (ignores TLS errors)
+$ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
+[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+
+$targets = @(
+  "https://portainer.lab.local:9443",
+  "https://wazuh.lab.local",
+  "https://thehive.lab.local",
+  "https://cortex.lab.local",
+  "https://caldera.lab.local",
+  "https://dvwa.lab.local",
+  "https://nessus.lab.local:8834"
+)
+
+$results = foreach($t in $targets){
+  try {
+    $r = Invoke-WebRequest -Uri $t -Method Head -TimeoutSec 8 -UseBasicParsing
+    [pscustomobject]@{ URL=$t; Status=$r.StatusCode; OK=$true }
+  } catch {
+    [pscustomobject]@{ URL=$t; Status=($_.Exception.Response.StatusCode.value__ 2>$null); OK=$false }
+  }
+}
+$results | Format-Table -AutoSize
+


### PR DESCRIPTION
## Summary
- support snapshot backups and retention in env example
- add Ansible backup playbook and PowerShell wrappers for backup, reset, and smoke test
- expose convenience make targets for backup, reset, and smoke

## Testing
- `ansible-lint ansible/site-backup.yml`
- `bandit -r scripts`
- `pytest`
- `make backup` *(fails: pwsh: No such file or directory)*
- `make smoke` *(fails: pwsh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899c9c9d3c8832d9f76541699152d7c