### PR TITLE
chore: configure lint rules and tidy docs

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120
+  },
+  "MD033": false
+}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,23 @@
+extends: default
+rules:
+  line-length:
+    max: 120
+    level: warning
+  braces:
+    max-spaces-inside: 1
+    level: warning
+  brackets:
+    max-spaces-inside: 1
+    level: warning
+  document-start: disable
+  truthy: disable
+  comments-indentation: false
+  colons: disable
+  commas:
+    min-spaces-after: 1
+    level: warning
+  comments:
+    min-spaces-from-content: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A pfSense-routed, k3s-managed SOC lab on VMware Workstation 17 Pro (Windows 11).
 **Apps:** Wazuh, TheHive, Cortex, CALDERA, DVWA, Kali (CLI), Nessus Essentials.
 
 ## Quickstart
+
 ```powershell
 git clone <repo-url> E:\SOC-9000\SOC-9000
 cd E:\SOC-9000\SOC-9000
@@ -93,7 +94,8 @@ You’ll see the pfSense console menu (numbered options). Do this:
     When asked which user can SSH: select admin (or allow both admin/root)
     Note the LAN IP shown in the banner.
 
-Immediately after install, pfSense may show 192.168.1.1 on LAN. Our automation will reassign LAN to 172.22.10.1 during the config import.
+Immediately after install, pfSense may show 192.168.1.1 on LAN.
+Our automation reassigns LAN to 172.22.10.1 during the config import.
 
 **Credentials:**
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,12 +1,12 @@
-lab_domain: "{{ lookup('env','LAB_DOMAIN') | default('lab.local') }}"
+lab_domain: "{{ lookup('env', 'LAB_DOMAIN') | default('lab.local') }}"
 pf:
-  mgmt_ip: "{{ lookup('env','PFSENSE_MGMT_IP') | default('172.22.10.1') }}"
-  soc_ip:  "{{ lookup('env','PFSENSE_SOC_IP')  | default('172.22.20.1') }}"
-  vic_ip:  "{{ lookup('env','PFSENSE_VICTIM_IP') | default('172.22.30.1') }}"
-  red_ip:  "{{ lookup('env','PFSENSE_RED_IP') | default('172.22.40.1') }}"
+  mgmt_ip: "{{ lookup('env', 'PFSENSE_MGMT_IP') | default('172.22.10.1') }}"
+  soc_ip: "{{ lookup('env', 'PFSENSE_SOC_IP') | default('172.22.20.1') }}"
+  vic_ip: "{{ lookup('env', 'PFSENSE_VICTIM_IP') | default('172.22.30.1') }}"
+  red_ip: "{{ lookup('env', 'PFSENSE_RED_IP') | default('172.22.40.1') }}"
 metallb:
   pools:
-    mgmt:   "{{ lookup('env','METALLB_POOL_MGMT') | default('172.22.10.50-172.22.10.99') }}"
-    soc:    "{{ lookup('env','METALLB_POOL_SOC') | default('172.22.20.50-172.22.20.199') }}"
-    victim: "{{ lookup('env','METALLB_POOL_VICTIM') | default('172.22.30.50-172.22.30.199') }}"
-    red:    "{{ lookup('env','METALLB_POOL_RED') | default('172.22.40.50-172.22.40.199') }}"
+    mgmt: "{{ lookup('env', 'METALLB_POOL_MGMT') | default('172.22.10.50-172.22.10.99') }}"
+    soc: "{{ lookup('env', 'METALLB_POOL_SOC') | default('172.22.20.50-172.22.20.199') }}"
+    victim: "{{ lookup('env', 'METALLB_POOL_VICTIM') | default('172.22.30.50-172.22.30.199') }}"
+    red: "{{ lookup('env', 'METALLB_POOL_RED') | default('172.22.40.50-172.22.40.199') }}"

--- a/docs/00-prereqs.md
+++ b/docs/00-prereqs.md
@@ -3,6 +3,7 @@
 Goal: Prepare Windows 11 + VMware Workstation for a pfSense-routed, k3s-managed, Portainer-controlled SOC lab.
 
 ## Requirements
+
 - Windows 11 (Administrator)
 - VMware Workstation 17 Pro (`vmrun`)
 - Git, PowerShell 7+, HashiCorp Packer
@@ -10,12 +11,13 @@ Goal: Prepare Windows 11 + VMware Workstation for a pfSense-routed, k3s-managed,
 
 ## Host folders
 
-E:\SOC-9000
-isos\ # pfSense/Ubuntu/Windows ISOs + Nessus .deb
-artifacts\ # Packer VM templates (output)
-temp\ # transient files
+- `E:\\SOC-9000`
+- `isos\\` — pfSense/Ubuntu/Windows ISOs + Nessus .deb
+- `artifacts\\` — Packer VM templates (output)
+- `temp\\` — transient files
 
 ## Networks (Virtual Network Editor)
+
 - `VMnet8` — NAT (DHCP ON)
 - `VMnet20` — MGMT `172.22.10.0/24` (DHCP OFF)
 - `VMnet21` — SOC  `172.22.20.0/24` (DHCP OFF)
@@ -24,14 +26,17 @@ temp\ # transient files
 
 > We emulate VLANs using multiple VMnets; pfSense has one NIC per segment.
 
-## Downloads (place into `E:\SOC-9000\isos`)
+## Downloads (place into `E:\\SOC-9000\\isos`)
+
 - pfSense CE ISO (AMD64)  → `pfsense.iso`
 - Ubuntu Server 22.04 ISO (AMD64) → `ubuntu-22.04.iso`
 - Windows 11 Evaluation ISO (EN-Intl) → `win11-eval.iso`
 - Nessus Essentials `.deb` (Ubuntu AMD64)
 
 ## SSH key
+
 Generate or reuse:
+
 ```powershell
 ssh-keygen -t ed25519 -C "soc-9000" -f $env:USERPROFILE\.ssh\id_ed25519
 
@@ -49,4 +54,5 @@ pwsh -ExecutionPolicy Bypass -File .\scripts\host-prepare.ps1
 
 ## Notes
 
-k3s uses containerd by default; Docker images run fine. We’ll add Portainer, Traefik (TLS for *.lab.local), and MetalLB IP pools per segment in later chunks.
+k3s uses containerd by default; Docker images run fine.
+We'll add Portainer, Traefik (TLS for *.lab.local), and MetalLB IP pools per segment in later chunks.


### PR DESCRIPTION
## Summary
- add yamllint and markdownlint configs for consistent style
- normalize spacing in Ansible group variables
- tidy Quickstart and host prerequisites docs

## Testing
- `markdownlint README.md docs/00-prereqs.md`
- `yamllint -s .`
- `ansible-lint ansible/group_vars/all.yml`


------
https://chatgpt.com/codex/tasks/task_e_6899ccf52228832dabb9923aff146b4d