### PR TITLE
Fix installer OS detection and Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ prereqs:
 
 # Build an executable version of the installer (requires PS2EXE).  Use Windows PowerShell as a fallback
 build-exe:
-pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/build-standalone-exe.ps1
+	@pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/build-standalone-exe.ps1
 
 # Install prerequisites and build the EXE in one step
 install-all:


### PR DESCRIPTION
## Summary
- ensure standalone installer detects Windows in PowerShell 5.1
- use approved verb names and suppress Write-Host analyzer warnings
- fix missing tab for build-exe recipe in Makefile

## Testing
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path scripts/standalone-installer.ps1; Write-Host 'PSScriptAnalyzer OK'"`
- `markdownlint '**/*.md' && echo 'markdownlint OK'`
- `make smoke`

------
https://chatgpt.com/codex/tasks/task_e_689b2948aa54832d8a29e23d930ecd9d