### PR TITLE
Robust downloads: pfSense mirrors, retries, vendor page fallback, content-type acceptance

### DIFF
--- a/scripts/download-isos.ps1
+++ b/scripts/download-isos.ps1
@@ -1,99 +1,135 @@
-# SOC-9000 - download-isos.ps1
+[CmdletBinding()]
+param(
+    [string]$IsoDir,
 
-<#
-    This script downloads the required ISO/installer files for the SOC‑9000 lab.  It is intended
-    for lab hosts running Windows with Internet access.  Files are downloaded only if they
-    are missing.  Run this script manually to fetch required images.
-
-    The default download folder is `E:\SOC-9000\isos`.  You can override this by passing
-    `-IsoDir` when invoking the script.
-
-    NOTE: Direct download URLs are provided for convenience.  You should verify these links
-    before running the script, and update them if the vendor releases new versions.  The
-    script performs a basic content-type check after downloading but does not validate
-    checksums.  For production use, you should verify the SHA256 sums against the official
-    sources.
-#>
-[CmdletBinding()] param(
-  [string]$IsoDir = "E:\\SOC-9000\\isos"
+    # Optional overrides; can also be provided via .env
+    [string]$UbuntuUrl  = $null,
+    [string]$PfSenseUrl = $null,   # If set, try this first; fallback to mirrors below
+    [string]$Win11Url   = $null,   # Expiring; open vendor page if empty
+    [string]$NessusUrl  = $null    # Gated; open vendor page if empty
 )
-$ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
 
-function New-Dir($p){ if(!(Test-Path $p)){ New-Item -Type Directory -Path $p -Force | Out-Null } }
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-# Ensure destination directory exists
-New-Dir $IsoDir
+# Nudge TLS12 for older hosts
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 } catch {}
 
-function Download-File {
+function Write-Info($m){ Write-Host $m -ForegroundColor Cyan }
+function Write-Good($m){ Write-Host $m -ForegroundColor Green }
+function Write-Warn($m){ Write-Warning $m }
+function Write-Err ($m){ Write-Error   $m }
+
+# Load .env if present for ISO_DIR/URL overrides
+$repoDir = Split-Path -Parent $PSCommandPath
+$rootDir = Split-Path -Parent $repoDir
+$envPath = Join-Path $rootDir '.env'
+if (-not $IsoDir) {
+    if (Test-Path $envPath) {
+        $line = Select-String -Path $envPath -Pattern '^\s*ISO_DIR=(.+)$' -ErrorAction SilentlyContinue
+        if ($line) { $IsoDir = $line.Matches.Value.Split('=')[1].Trim() }
+    }
+    if (-not $IsoDir) { $IsoDir = Join-Path $rootDir 'isos' }
+}
+New-Item -ItemType Directory -Path $IsoDir -Force | Out-Null
+
+# Defaults (can be overridden by params or .env)
+if (-not $UbuntuUrl)  { $UbuntuUrl  = 'https://releases.ubuntu.com/jammy/ubuntu-22.04.5-live-server-amd64.iso' }
+# NOTE: pfSense links/mirrors change; we keep a short list and also open the download page if all fail.
+$pfMirrors = @(
+  'https://mirror.pfsense.org/amd64/installer/pfSense-CE-2.7.3-RELEASE-amd64.iso',
+  'https://atxfiles.pfsense.org/mirror/downloads/pfSense-CE-2.7.3-RELEASE-amd64.iso',
+  'https://frafiles.pfsense.org/mirror/downloads/pfSense-CE-2.7.3-RELEASE-amd64.iso',
+  'https://nyifiles.pfsense.org/mirror/downloads/pfSense-CE-2.7.3-RELEASE-amd64.iso'
+)
+
+$AllowedIsoContentTypes = @(
+  'application/x-iso9660-image','application/octet-stream',
+  'application/download','binary/octet-stream','application/x-download'
+)
+
+function Invoke-Download {
     param(
-        [Parameter(Mandatory)] [string]$Url,
+        [Parameter(Mandatory)] [string]$Uri,
         [Parameter(Mandatory)] [string]$OutFile,
-        [string]$ExpectedContentType = ""
+        [int]$MaxTries = 3,
+        [int]$TimeoutSec = 300
     )
-    $fname = Split-Path $OutFile -Leaf
-    if (Test-Path $OutFile) {
-        Write-Host "[+] $fname already exists. Skipping download."
-        return
-    }
-    Write-Host "[*] Downloading $fname..."
-    try {
-        # Some vendors require TLS 1.2
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        $headers = @{ 'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' }
-        Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing -Headers $headers
-    } catch {
-        Write-Warning "Failed to download ${Url}: $_"
-        return
-    }
-    # Basic validation
-    if ($ExpectedContentType) {
+    $ua = @{ 'User-Agent' = 'SOC-9000/installer' }
+    for ($i=1; $i -le $MaxTries; $i++) {
         try {
-            $resp = Invoke-WebRequest -Uri $Url -Method Head -UseBasicParsing
-            if ($resp.Headers['Content-Type'] -and $resp.Headers['Content-Type'] -notlike "*${ExpectedContentType}*") {
-                Write-Warning "$fname downloaded but content-type mismatch: $($resp.Headers['Content-Type'])"
+            Write-Info "[*] Downloading $(Split-Path -Leaf $OutFile) (try $i/$MaxTries)..."
+            $resp = Invoke-WebRequest -Uri $Uri -OutFile $OutFile -Headers $ua -TimeoutSec $TimeoutSec -UseBasicParsing -ErrorAction Stop
+            $ct = $resp.Headers['Content-Type']
+            if ($ct -and -not ($AllowedIsoContentTypes -contains $ct)) {
+                Write-Warn "Downloaded but content-type '$ct' is unusual for ISO; keeping file."
+            }
+            if ((Test-Path $OutFile) -and ((Get-Item $OutFile).Length -gt 10MB)) {
+                $mb = [math]::Round((Get-Item $OutFile).Length/1MB,1)
+                Write-Good "[+] Saved $(Split-Path -Leaf $OutFile) ($mb MB)"
+                return $true
+            } else {
+                Write-Warn "File seems too small after download."
             }
         } catch {
-            # ignore HEAD failures
+            Write-Warn "Download failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds ([Math]::Min(5*$i, 20))
         }
     }
-    $size = (Get-Item $OutFile).Length / 1MB
-    Write-Host "[+] Saved $fname ($([math]::Round($size,1)) MB)"
+    return $false
 }
 
-# Define download URLs
-$downloads = @{
-    "pfsense.iso" = @{
-        urls = @(
-            "https://nyifiles.pfsense.org/mirror/downloads/pfSense-CE-2.7.3-RELEASE-amd64.iso",
-            "https://frafiles.pfsense.org/mirror/downloads/pfSense-CE-2.7.3-RELEASE-amd64.iso",
-            "https://atxfiles.pfsense.org/mirror/downloads/pfSense-CE-2.7.3-RELEASE-amd64.iso"
-        );
-        type = "application/octet-stream"
+function Ensure-FromUrls {
+    param(
+        [Parameter(Mandatory)] [string]$OutFile,
+        [Parameter(Mandatory)] [string[]]$Urls
+    )
+    if (Test-Path $OutFile) { Write-Good "[=] Exists: $(Split-Path -Leaf $OutFile)"; return $true }
+    foreach ($u in $Urls) {
+        if (Invoke-Download -Uri $u -OutFile $OutFile) { return $true }
     }
-    "ubuntu-22.04.iso" = @{
-        urls = @("https://releases.ubuntu.com/22.04.5/ubuntu-22.04.5-live-server-amd64.iso");
-        type = "application/octet-stream"
-    }
-    "win11-eval.iso" = @{
-        urls = @("https://software-download.microsoft.com/download/pr/Win11_23H2_English_x64v2.iso");
-        type = "application/octet-stream"
-    }
-    "nessus_latest_amd64.deb" = @{
-        urls = @("https://www.tenable.com/downloads/api/v1/public/pages/nessus/downloads/26139/download?i_agree_to_tenable_license_agreement=true");
-        type = "application/x-debian-package"
-    }
+    return $false
 }
 
-foreach ($item in $downloads.GetEnumerator()) {
-    $dest = Join-Path $IsoDir $item.Key
-    foreach ($url in $item.Value.urls) {
-        if (Test-Path $dest) { break }
-        Download-File -Url $url -OutFile $dest -ExpectedContentType $item.Value.type
+function Ensure-OrOpenVendor {
+    param(
+        [Parameter(Mandatory)] [string]$OutFile,
+        [string]$UrlIfAny,
+        [string]$VendorPage
+    )
+    if (Test-Path $OutFile) { Write-Good "[=] Exists: $(Split-Path -Leaf $OutFile)"; return }
+    if ($UrlIfAny) {
+        if (Invoke-Download -Uri $UrlIfAny -OutFile $OutFile) { return }
     }
-    if (!(Test-Path $dest)) {
-        Write-Warning "$($item.Key) could not be downloaded from any mirror. Please download it manually."
-    }
+    Write-Warn "$(Split-Path -Leaf $OutFile) requires a gated or expiring URL. Opening vendor page…"
+    if ($VendorPage) { try { Start-Process $VendorPage } catch { Write-Warn "Could not open browser: $($_.Exception.Message)" } }
+    Write-Info  "Please download manually and place it at: $OutFile"
 }
 
-Write-Host "All downloads complete."
+# Targets
+$UbuntuIso  = Join-Path $IsoDir 'ubuntu-22.04.iso'
+$PfSenseIso = Join-Path $IsoDir 'pfsense.iso'
+$Win11Iso   = Join-Path $IsoDir 'win11-eval.iso'
+$NessusDeb  = Join-Path $IsoDir 'nessus_latest_amd64.deb'
 
+# Ubuntu (static)
+Ensure-FromUrls -OutFile $UbuntuIso -Urls @($UbuntuUrl) | Out-Null
+
+# pfSense (try override then mirrors; if all fail, open download page)
+$pfList = @()
+if ($PfSenseUrl) { $pfList += $PfSenseUrl }
+$pfList += $pfMirrors
+if (-not (Ensure-FromUrls -OutFile $PfSenseIso -Urls $pfList)) {
+    Write-Warn "pfSense ISO could not be fetched from mirrors. This can be DNS or certificate time issues."
+    Write-Info "Opening pfSense download page so you can pick a nearby mirror…"
+    try { Start-Process 'https://www.pfsense.org/download/' } catch {}
+    Write-Info "After download, save as: $PfSenseIso"
+}
+
+# Windows 11 Eval (expiring)
+Ensure-OrOpenVendor -OutFile $Win11Iso -UrlIfAny $Win11Url -VendorPage 'https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise'
+
+# Nessus (gated)
+Ensure-OrOpenVendor -OutFile $NessusDeb -UrlIfAny $NessusUrl -VendorPage 'https://www.tenable.com/products/nessus/nessus-essentials'
+
+Write-Good "All downloads complete (or vendor pages opened)."


### PR DESCRIPTION
## Summary
- Replace download script with resilient PowerShell implementation
- Add pfSense mirror list, retry logic, and vendor page fallbacks for gated downloads
- Accept common ISO content types and allow URL overrides via parameters or `.env`

## Testing
- `pytest`
- `npm audit`
- `pwsh -NoProfile -Command "if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) { Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser }; Invoke-ScriptAnalyzer -Path scripts/download-isos.ps1"` *(warnings: PSAvoidUsingWriteHost, PSUseApprovedVerbs, PSUseBOMForUnicodeEncodedFile, PSUseSingularNouns)*

------
https://chatgpt.com/codex/tasks/task_e_689c5eff03e0832dabba37873bced840