### PR TITLE
docs(installer): clarify manual placement path when downloads are gated

### DIFF
--- a/scripts/standalone-installer.ps1
+++ b/scripts/standalone-installer.ps1
@@ -212,6 +212,7 @@ if (-not $SkipIsoDownload) {
     if ($PSCmdlet.ShouldProcess("Download ISOs to $isoDir")) {
         $downloadIsos = Join-Path $ScriptsDir 'download-isos.ps1'
                 Invoke-PowerShellScript -ScriptPath $downloadIsos -Arguments @('-IsoDir', $isoDir)
+                Write-Host "Note: If pfSense/Win11/Nessus did not download automatically, their official pages were opened. Save the files into: $isoDir and re-run." -ForegroundColor Yellow
     }
 }
 


### PR DESCRIPTION
## Summary
- add note in standalone installer about manually placing pfSense/Win11/Nessus downloads when gated

## Testing
- `make check` *(fails: PowerShell not found; skipping check target)*
- `npm test` *(fails: Missing script: "test")*
- `npm audit`
- `pwsh -NoProfile -Command "Install-Module PSScriptAnalyzer -Force -Scope CurrentUser; Invoke-ScriptAnalyzer -Path scripts/standalone-installer.ps1"` *(fails: command not found: pwsh)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689c628306a0832d9956c4edc4d0097f