### PR TITLE
Add SHA256 validation: scripts/verify-hashes.ps1 + checksums.txt support

### DIFF
--- a/checksums.txt
+++ b/checksums.txt
@@ -1,0 +1,15 @@
+# checksums.txt - place the official SHA256 for each file you want to validate
+# Format accepted:
+#   <SHA256>  <filename>
+# or:
+#   <filename>  <SHA256>
+
+# Examples (replace with vendor values)
+# jammy 22.04.5:
+# 9f4f08a5f8c2a34e3e9c9d7fd7b...<truncated>...  ubuntu-22.04.iso
+# pfSense CE 2.7.3:
+# <official sha256>  pfsense.iso
+# Windows 11 Eval:
+# <official sha256>  win11-eval.iso
+# Nessus Essentials:
+# <official sha256>  nessus_latest_amd64.deb

--- a/scripts/verify-hashes.ps1
+++ b/scripts/verify-hashes.ps1
@@ -1,38 +1,208 @@
 [CmdletBinding()]
 param(
-    [string]$IsoDir
+    [string]$IsoDir,
+    [string]$ChecksumsPath,     # optional; auto-locate if omitted
+    [switch]$Strict,            # if set, exit nonzero on mismatch/missing
+    [string]$OutPath            # if provided, write actual hashes to this file
 )
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Get-EnvOrDefault($key,$def){
-    if ($env:$key) { return $env:$key }
+function Resolve-IsoDir {
+    param([string]$Given)
+    if ($Given) { return [IO.Path]::GetFullPath($Given) }
+    # Try .env -> ISO_DIR
     $envPath = Join-Path (Split-Path -Parent $PSScriptRoot) '..\.env'
     if (Test-Path $envPath) {
-        $line = Select-String -Path $envPath -Pattern "^\s*$key=(.+)$" -ErrorAction SilentlyContinue
-        if ($line) { return $line.Matches.Value.Split('=')[1].Trim() }
+        $line = Select-String -Path $envPath -Pattern '^\s*ISO_DIR=(.+)$' -ErrorAction SilentlyContinue
+        if ($line) {
+            $dir = $line.Matches.Value.Split('=')[1].Trim()
+            if ($dir) { return [IO.Path]::GetFullPath($dir) }
+        }
     }
-    return $def
+    # Default fallback
+    return [IO.Path]::GetFullPath((Join-Path (Split-Path -Parent $PSScriptRoot) '..\isos'))
 }
 
-if (-not $IsoDir) { $IsoDir = Get-EnvOrDefault 'ISO_DIR' (Join-Path (Split-Path -Parent $PSScriptRoot) '..\isos') }
-$IsoDir = [IO.Path]::GetFullPath($IsoDir)
+function Find-ChecksumsFile {
+    param([string]$IsoDir,[string]$Given)
+    if ($Given) { return [IO.Path]::GetFullPath($Given) }
+    $c1 = Join-Path $IsoDir 'checksums.txt'
+    if (Test-Path $c1) { return $c1 }
+    $root = [IO.Path]::GetFullPath((Join-Path (Split-Path -Parent $PSScriptRoot) '..'))
+    $c2 = Join-Path $root 'checksums.txt'
+    if (Test-Path $c2) { return $c2 }
+    return $null
+}
 
+function Get-ActualHashes {
+    param([string]$IsoDir,[string[]]$Candidates)
+    $results = @()
+    foreach ($name in $Candidates) {
+        $path = Join-Path $IsoDir $name
+        if (Test-Path $path) {
+            $h = Get-FileHash -Algorithm SHA256 -Path $path
+            $results += [pscustomobject]@{
+                File = $name
+                Path = $path
+                SHA256 = $h.Hash.ToUpperInvariant()
+                Exists = $true
+            }
+        } else {
+            $results += [pscustomobject]@{
+                File = $name
+                Path = $path
+                SHA256 = ''
+                Exists = $false
+            }
+        }
+    }
+    return $results
+}
+
+function Parse-Checksums {
+    param([string]$Path)
+    # Supported formats (case-insensitive):
+    # 1) sha256  filename.ext            (common)
+    # 2) sha256 *filename.ext            (GNU 'sha256sum' style)
+    # 3) filename.ext  sha256            (we also accept this)
+    # Ignore blank lines and lines starting with '#' or ';'
+    $map = @{}
+    $lines = Get-Content -Path $Path -ErrorAction Stop
+    foreach ($raw in $lines) {
+        $line = $raw.Trim()
+        if (-not $line) { continue }
+        if ($line.StartsWith('#') -or $line.StartsWith(';')) { continue }
+
+        $hash = $null; $file = $null
+
+        # Pattern 1/2: ^([0-9a-f]{64})\s+\*?(.+)$
+        $m1 = [regex]::Match($line, '^([0-9A-Fa-f]{64})\s+\*?(.+)$')
+        if ($m1.Success) {
+            $hash = $m1.Groups[1].Value.ToUpperInvariant()
+            $file = $m1.Groups[2].Value.Trim()
+        } else {
+            # Pattern 3: ^(.+?)\s+([0-9a-f]{64})$
+            $m2 = [regex]::Match($line, '^(.+?)\s+([0-9A-Fa-f]{64})$')
+            if ($m2.Success) {
+                $file = $m2.Groups[1].Value.Trim()
+                $hash = $m2.Groups[2].Value.ToUpperInvariant()
+            }
+        }
+
+        if ($file -and $hash) {
+            $map[$file] = $hash
+        }
+    }
+    return $map
+}
+
+function Write-Table {
+    param($rows)
+    $widthFile = ($rows | ForEach-Object { $_.File.Length } | Measure-Object -Maximum).Maximum
+    if (-not $widthFile -or $widthFile -lt 12) { $widthFile = 12 }
+    foreach ($r in $rows) {
+        $status = if ($r.Status) { $r.Status } else { '' }
+        "{0,-$widthFile}  {1}  {2}" -f $r.File, $r.SHA256, $status
+    }
+}
+
+# --- Main ---
+$IsoDir = Resolve-IsoDir -Given $IsoDir
 Write-Host "ISO dir: $IsoDir" -ForegroundColor Cyan
 if (-not (Test-Path $IsoDir)) { Write-Error "Missing folder: $IsoDir"; exit 1 }
 
-$targets = @(
+# Known default filenames
+$DefaultFiles = @(
   'ubuntu-22.04.iso',
   'pfsense.iso',
   'win11-eval.iso',
   'nessus_latest_amd64.deb'
-) | ForEach-Object { Join-Path $IsoDir $_ }
+)
 
-foreach ($f in $targets) {
-    if (Test-Path $f) {
-        $h = Get-FileHash -Algorithm SHA256 -Path $f
-        "{0,-22}  {1}" -f (Split-Path -Leaf $f), $h.Hash
+$ChecksumsPath = Find-ChecksumsFile -IsoDir $IsoDir -Given $ChecksumsPath
+
+if ($OutPath) {
+    # Emit actual hashes file for whatever exists
+    $actual = Get-ActualHashes -IsoDir $IsoDir -Candidates $DefaultFiles
+    $lines = @()
+    foreach ($a in $actual) {
+        if ($a.Exists) {
+            $lines += ("{0}  {1}" -f $a.SHA256, $a.File)
+        } else {
+            $lines += ("# (missing)  {0}" -f $a.File)
+        }
+    }
+    Set-Content -Path $OutPath -Value $lines -Encoding ASCII
+    Write-Host "Wrote actual hashes to: $OutPath" -ForegroundColor Green
+    exit 0
+}
+
+if (-not $ChecksumsPath) {
+    # Create a template next to ISO dir and instruct the user
+    $tmpl = Join-Path $IsoDir 'checksums.txt'
+    $tplLines = @(
+        '# checksums.txt - SHA256 hashes for SOC-9000 downloads',
+        '# Format (either is accepted):',
+        '#   <SHA256>  <filename>',
+        '#   <filename>  <SHA256>',
+        '# Lines starting with # or ; are ignored.',
+        '',
+        '# Example (replace the hash with the vendor-provided value):',
+        '# 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF  ubuntu-22.04.iso',
+        '# 89ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01234567  pfsense.iso',
+        '# win11-eval.iso  FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210',
+        '# nessus_latest_amd64.deb  76543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA98'
+    )
+    Set-Content -Path $tmpl -Value $tplLines -Encoding ASCII
+    Write-Warning "No checksums file found. A template was created at: $tmpl"
+    Write-Host  "Tip: Generate actual hashes to fill it:" -ForegroundColor Yellow
+    Write-Host  "  pwsh -File scripts/verify-hashes.ps1 -OutPath $tmpl" -ForegroundColor Yellow
+    exit 0
+}
+
+Write-Host "Checksums file: $ChecksumsPath" -ForegroundColor Cyan
+$Expect = Parse-Checksums -Path $ChecksumsPath
+
+# Build candidate list from checksums + defaults
+$AllNames = New-Object System.Collections.Generic.HashSet[string]
+foreach ($k in $Expect.Keys) { [void]$AllNames.Add($k) }
+foreach ($d in $DefaultFiles) { [void]$AllNames.Add($d) }
+$Candidates = @($AllNames)
+
+$Actual = Get-ActualHashes -IsoDir $IsoDir -Candidates $Candidates
+
+# Compare
+$rows = @()
+$missing = 0; $mismatch = 0; $ok = 0
+foreach ($a in $Actual) {
+    $exp = $null
+    if ($Expect.ContainsKey($a.File)) { $exp = $Expect[$a.File] }
+    $status = ''
+    if (-not $a.Exists) {
+        $status = 'MISSING'
+        $missing++
+    } elseif ($exp) {
+        if ($exp -eq $a.SHA256) { $status = 'OK'; $ok++ }
+        else { $status = 'MISMATCH'; $mismatch++ }
     } else {
-        "{0,-22}  (missing)" -f (Split-Path -Leaf $f)
+        $status = 'NO-EXPECTED'  # not listed in checksums
+    }
+    $rows += [pscustomobject]@{
+        File = $a.File
+        SHA256 = if ($a.Exists) { $a.SHA256 } else { '' }
+        Status = $status
     }
 }
+
+Write-Host ""
+Write-Table -rows $rows | Out-Host
+Write-Host ""
+
+Write-Host ("Summary: OK={0}  MISMATCH={1}  MISSING={2}  TOTAL={3}" -f $ok,$mismatch,$missing,$rows.Count) -ForegroundColor Cyan
+
+if ($Strict) {
+    if ($mismatch -gt 0 -or $missing -gt 0) { exit 2 }
+}
+exit 0


### PR DESCRIPTION
## Summary
- enhance verify-hashes.ps1 to validate ISO SHA256s, auto-generate templates, and support strict checks
- add repository-wide checksums.txt template

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm audit`
- `npm run lint` *(fails: Missing script "lint")*
- `pytest`
- `pip-audit` *(fails: certificate verify failed: Missing Authority Key Identifier)*
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path scripts/verify-hashes.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c65a349a8832d9713bc2721247d36