### PR TITLE
Simplify ISO download flow with manual vendor pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SOC‑9000 offers three ways to get started, depending on your level of comfort 
    pwsh -File .\scripts\lab-up.ps1
    ```
 
-   This method is ideal if you don’t want to use Git but are comfortable running a few commands.
+   The download script fetches Ubuntu automatically and opens vendor pages for pfSense, Windows 11, and Nessus so you can download them manually. This method is ideal if you don’t want to use Git but are comfortable running a few commands.
 3. **Git clone (contributor/developer)** — If you plan to contribute or prefer to work directly with the source repository, clone it and run the scripts yourself.  See below.
 
 ### Clone and initialize (contributor/developer path)

--- a/docs/00-prereqs.md
+++ b/docs/00-prereqs.md
@@ -35,13 +35,13 @@ The lab requires several ISO and installer files that are **not included** in th
 - Windows 11 Evaluation ISO (English)
 - Nessus Essentials `.deb` (Ubuntu AMD64)
 
-You may download these yourself and place them into `E:\SOC-9000\isos`, **or** you can use the helper script to fetch them automatically.  From the repo root run:
+You may download these yourself and place them into `E:\SOC-9000\isos`, **or** you can use the helper script to fetch Ubuntu automatically and open vendor pages for the rest.  From the repo root run:
 
 ```powershell
 pwsh -File .\scripts\download-isos.ps1
 ```
 
-The script checks for existing files and downloads what’s missing, using known good URLs from the vendors.  Feel free to edit `scripts/download-isos.ps1` if you need to update the URLs.
+The script downloads Ubuntu automatically and opens vendor pages for pfSense, Windows 11, and Nessus so you can fetch them manually. Feel free to edit `scripts/download-isos.ps1` if you need to update the URLs.
 
 ## Install prerequisites
 

--- a/docs/BEGINNER-GUIDE.md
+++ b/docs/BEGINNER-GUIDE.md
@@ -46,7 +46,7 @@ The lab requires several OS images that are **not** stored in this repository.  
 - **pfSense ISO** – firewall/router installer
 - **Nessus Essentials (.deb)** – optional for the Nessus VM path
 
-To download these automatically:
+To fetch the images:
 
 1. Open **PowerShell as Administrator** and navigate to your cloned repo:
    ```powershell
@@ -57,7 +57,7 @@ To download these automatically:
    pwsh -File .\scripts\download-isos.ps1
    ```
 
-The script checks your `isos` folder (`E:\SOC-9000\isos` by default), downloads each file if it does not already exist, and verifies basic properties (size and type).  Direct download URLs are embedded in the script; you can update them if new releases become available.  If you prefer to supply your own ISOs, you can place them in the folder and the script will skip downloading.
+The script checks your `isos` folder (`E:\SOC-9000\isos` by default), downloads Ubuntu automatically if it is missing, and opens vendor pages for pfSense, Windows 11, and Nessus so you can download them manually. If you prefer to supply your own files, place them in the folder and the script will skip them.
 
 ### One‑click installer
 

--- a/scripts/download-isos.ps1
+++ b/scripts/download-isos.ps1
@@ -3,14 +3,7 @@ param(
     [string]$IsoDir,
 
     # Optional overrides; can also be provided via .env
-    [string]$UbuntuUrl  = $null,
-    # pfSense ISO: if provided, the script will attempt to download from this URL.  If omitted,
-    # the pfSense download page will be opened directly for a manual download.
-    [string]$PfSenseUrl = $null,
-    # Windows 11 ISO: provide a direct download URL to attempt an automated fetch.
-    [string]$Win11Url   = $null,
-    # Nessus package: provide a direct download URL to attempt an automated fetch.
-    [string]$NessusUrl  = $null
+    [string]$UbuntuUrl  = $null
 )
 
 Set-StrictMode -Version Latest
@@ -45,13 +38,9 @@ New-Item -ItemType Directory -Path $IsoDir -Force | Out-Null
 # Defaults (can be overridden by params or .env)
 if (-not $UbuntuUrl)  { $UbuntuUrl  = 'https://releases.ubuntu.com/jammy/ubuntu-22.04.5-live-server-amd64.iso' }
 
-# pfSense downloads previously attempted to use multiple mirrors to fetch the ISO.
-# In practice these URLs often fail due to DNS or certificate issues.  To simplify
-# the user experience, we no longer try a series of mirrors.  Instead, if a
-# specific URL is provided via -PfSenseUrl we will attempt to download from it;
-# otherwise we immediately open the pfSense vendor page so the user can choose
-# their nearest mirror manually.  See the pfSense documentation for details.
-$pfMirrors = @()
+# pfSense, Windows 11 and Nessus require gated or expiring URLs.  We no longer
+# attempt automatic downloads for these files; instead the script immediately
+# opens the vendor page so the user can obtain the latest image manually.
 
 $AllowedIsoContentTypes = @(
   'application/x-iso9660-image','application/octet-stream',
@@ -104,7 +93,6 @@ function Ensure-FromUrls {
 function Ensure-OrOpenVendor {
     param(
         [Parameter(Mandatory)] [string]$OutFile,
-        [string]$UrlIfAny,
         [string]$VendorPage
     )
     # If the file already exists, nothing to do
@@ -112,11 +100,7 @@ function Ensure-OrOpenVendor {
         Write-Good "[=] Exists: $(Split-Path -Leaf $OutFile)"
         return
     }
-    # Attempt direct download if a URL override was provided
-    if ($UrlIfAny) {
-        if (Invoke-Download -Uri $UrlIfAny -OutFile $OutFile) { return }
-    }
-    # Fall back to manual download: open the vendor page and defer prompting
+    # Always open the vendor page for manual download
     Write-Warn "$(Split-Path -Leaf $OutFile) requires a gated or expiring URL. Opening vendor page…"
     if ($VendorPage) {
         try { Start-Process $VendorPage } catch { Write-Warn "Could not open browser: $($_.Exception.Message)" }
@@ -136,30 +120,22 @@ $NessusDeb  = Join-Path $IsoDir 'nessus_latest_amd64.deb'
 # Ubuntu (static)
 Ensure-FromUrls -OutFile $UbuntuIso -Urls @($UbuntuUrl) | Out-Null
 
-# pfSense: open vendor page for manual download by default.  If a PfSenseUrl
-# override is supplied, attempt a direct download; otherwise open the pfSense
-# download page for the user.
-Ensure-OrOpenVendor -OutFile $PfSenseIso -UrlIfAny $PfSenseUrl -VendorPage 'https://www.pfsense.org/download/'
+# pfSense: always open vendor page for manual download.
+Ensure-OrOpenVendor -OutFile $PfSenseIso -VendorPage 'https://www.pfsense.org/download/'
 
 # Windows 11 ISO (International)
-# The official Microsoft download page requires you to choose an edition and language
-# and provides a time-limited URL for the ISO.  If you provide a direct URL via
-# -Win11Url, the installer will attempt to download it.  Otherwise the script
-# opens the official download page where you can select "Windows 11" and language
-# "English International" (x64) and save the ISO.  Once downloaded, copy or
-# rename the file into ISO_DIR.  If you download a file with a different name
-# (e.g. Win11_23H2_EnglishInternational_x64.iso), simply rename it to match
-# $Win11Iso or adjust your .env ISO_DIR accordingly.
-Ensure-OrOpenVendor -OutFile $Win11Iso -UrlIfAny $Win11Url -VendorPage 'https://www.microsoft.com/de-de/software-download/windows11'
+# The official Microsoft download page provides a time-limited URL for the ISO.
+# The script opens the page so you can select the edition and language and save
+# the ISO manually.  Rename the file to match $Win11Iso or adjust your .env
+# if the vendor uses a versioned name.
+Ensure-OrOpenVendor -OutFile $Win11Iso -VendorPage 'https://www.microsoft.com/de-de/software-download/windows11'
 
 # Nessus (gated)
 # Tenable’s Nessus downloads require you to sign up for a Nessus Essentials key
-# before the download link becomes available.  If no direct URL is provided
-# via -NessusUrl, the installer will open the Nessus Essentials registration
-# page.  Register with a disposable email address, obtain the download link and
-# save the .deb package into your ISO_DIR.  After placing the file, press
-# Enter when prompted to continue.
-Ensure-OrOpenVendor -OutFile $NessusDeb -UrlIfAny $NessusUrl -VendorPage 'https://www.tenable.com/products/nessus/nessus-essentials'
+# before the download link becomes available.  The installer opens the
+# registration page so you can obtain the download link and save the package
+# manually.  After placing the file, press Enter when prompted to continue.
+Ensure-OrOpenVendor -OutFile $NessusDeb -VendorPage 'https://www.tenable.com/products/nessus/nessus-essentials'
 
 # Unified prompt: if any manual downloads were required, prompt once at the end
 if ($script:manualFilesNeeded) {

--- a/scripts/host-prepare.ps1
+++ b/scripts/host-prepare.ps1
@@ -57,6 +57,6 @@ Write-Host "`nNext steps:"
    - Ubuntu 22.04 (AMD64)-> $(Join-Path $IsoDir 'ubuntu-22.04.iso')
    - Windows 11 Eval     -> $(Join-Path $IsoDir 'win11-eval.iso')
    - Nessus Essentials .deb (Ubuntu AMD64)"
-"   (Tip: run scripts\download-isos.ps1 to download these automatically)"
+"   (Tip: run scripts\download-isos.ps1 to fetch Ubuntu automatically and open vendor pages for the rest)"
 "3) Ensure SSH key at %USERPROFILE%\.ssh\id_ed25519 (or create it)."
 "4) (Optional) Copy SSH key into WSL: scripts\copy-ssh-key-to-wsl.ps1"

--- a/scripts/standalone-installer.ps1
+++ b/scripts/standalone-installer.ps1
@@ -117,16 +117,6 @@ function Test-Packer {
 # where to save the evaluation ISO.  Users can avoid renaming by simply
 # placing any ISO whose name contains "win" and "11" in the isos folder; the
 # summary below will detect it automatically.
-function Get-Win11IsoName {
-    param([string]$IsoDir)
-    $patterns = @('win11*.iso','windows11*.iso','win*.iso','windows*.iso')
-    foreach ($pat in $patterns) {
-        $file = Get-ChildItem -Path $IsoDir -Filter $pat -ErrorAction SilentlyContinue | Where-Object { $_.Name -match '11' } | Sort-Object -Property Length -Descending | Select-Object -First 1
-        if ($file) { return $file.Name }
-    }
-    # Default target name for the installer to use when saving an evaluation ISO
-    return 'win11-eval.iso'
-}
 
 function Run-PowerShellScript {
     param(
@@ -242,19 +232,62 @@ if (-not $SkipIsoDownload) {
     if ($PSCmdlet.ShouldProcess("Download ISOs to $isoDir")) {
         $downloadIsos = Join-Path $ScriptsDir 'download-isos.ps1'
         Run-PowerShellScript -ScriptPath $downloadIsos -Arguments @('-IsoDir', $isoDir)
-        Write-Host "Note: If pfSense/Windows/Nessus did not download automatically, their official pages were opened. Save the files into: $isoDir and re-run." -ForegroundColor Yellow
+        Write-Host "Note: pfSense/Win11/Nessus require manual downloads. Their official pages were opened. Save the files into: $isoDir and re-run." -ForegroundColor Yellow
     }
 }
 
+# --- Dynamic ISO name detection helpers (run after $isoDir is defined) ---
+function Find-FirstMatchingFile {
+    param(
+        [Parameter(Mandatory)] [string]$Dir,
+        [Parameter(Mandatory)] [string[]]$Patterns  # array of regex patterns (case-insensitive)
+    )
+    if (-not (Test-Path $Dir)) { return $null }
+    $files = Get-ChildItem -Path $Dir -File -ErrorAction SilentlyContinue
+    foreach ($p in $Patterns) {
+        $match = $files | Where-Object { $_.Name -match $p } | Select-Object -First 1
+        if ($match) { return $match }
+    }
+    return $null
+}
+
+# Windows 11: accept typical vendor/versioned names (e.g., Win11_23H2_EnglishInternational_x64.iso)
+# Match any ISO that mentions 'Windows' or 'Win' and '11' anywhere in the name.
+$Win11Detected = Find-FirstMatchingFile -Dir $isoDir -Patterns @('(?i).*win(dows)?[^\w]*11.*\.iso$')
+if ($Win11Detected) {
+    $Win11IsoPath = $Win11Detected.FullName
+    $Win11Display = $Win11Detected.Name
+} else {
+    $Win11IsoPath = Join-Path $isoDir 'win11-eval.iso'  # legacy default name
+    $Win11Display = 'win11-eval.iso'
+}
+
+# pfSense: accept vendor-style names (pfSense-CE-<ver>-RELEASE-amd64.iso) or fallback to pfsense.iso
+$PfSenseDetected = Find-FirstMatchingFile -Dir $isoDir -Patterns @('(?i)^pfsense.*\.iso$')
+if ($PfSenseDetected) {
+    $PfSenseIsoPath = $PfSenseDetected.FullName
+    $PfSenseDisplay = $PfSenseDetected.Name
+} else {
+    $PfSenseIsoPath = Join-Path $isoDir 'pfsense.iso'
+    $PfSenseDisplay = 'pfsense.iso'
+}
+
+# Nessus: accept versioned/generic names (e.g., nessus-10.x.x-amd64.deb)
+$NessusDetected = Find-FirstMatchingFile -Dir $isoDir -Patterns @('(?i)^nessus.*amd64.*\.deb$')
+if ($NessusDetected) {
+    $NessusDebPath = $NessusDetected.FullName
+    $NessusDisplay = $NessusDetected.Name
+} else {
+    $NessusDebPath = Join-Path $isoDir 'nessus_latest_amd64.deb'
+    $NessusDisplay = 'nessus_latest_amd64.deb'
+}
+
 # --- Download Summary ---
-# Determine the Windows 11 ISO name dynamically.  If multiple ISOs are present
-# you may adjust this function as needed.  See Get-Win11IsoName above.
-$winIsoName  = Get-Win11IsoName -IsoDir $isoDir
 $requiredFiles = @(
-    @{ Name = 'ubuntu-22.04.iso';          Path = Join-Path $isoDir 'ubuntu-22.04.iso' },
-    @{ Name = 'pfsense.iso';               Path = Join-Path $isoDir 'pfsense.iso' },
-    @{ Name = $winIsoName;                 Path = Join-Path $isoDir $winIsoName },
-    @{ Name = 'nessus_latest_amd64.deb';   Path = Join-Path $isoDir 'nessus_latest_amd64.deb' }
+    @{ Name = 'ubuntu-22.04.iso'; Path = Join-Path $isoDir 'ubuntu-22.04.iso' },
+    @{ Name = $PfSenseDisplay;   Path = $PfSenseIsoPath },
+    @{ Name = $Win11Display;     Path = $Win11IsoPath },
+    @{ Name = $NessusDisplay;    Path = $NessusDebPath }
 )
 
 Write-Host "`n== Download Summary ==" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- stop automatic fetching of pfSense, Windows 11 and Nessus; always open vendor pages
- detect versioned ISO filenames in standalone installer
- document manual download workflow in host preparation and guides

## Testing
- `npx -y markdownlint-cli README.md docs/00-prereqs.md docs/BEGINNER-GUIDE.md`
- `npm audit --production`
- `pwsh -NoProfile -File scripts/smoke-test.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c95df1a5c832d895d3fa21a029933