### PR TITLE
Simplify ISO download flow with manual vendor pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SOC‑9000 offers three ways to get started, depending on your level of comfort 
    pwsh -File .\scripts\lab-up.ps1
    ```
 
-   This method is ideal if you don’t want to use Git but are comfortable running a few commands.
+   The download script fetches Ubuntu automatically and opens vendor pages for pfSense, Windows 11, and Nessus so you can download them manually. pfSense and Nessus require free accounts; a burner email works fine. Files can keep their vendor‑supplied names—the installer detects them automatically. This method is ideal if you don’t want to use Git but are comfortable running a few commands.
 3. **Git clone (contributor/developer)** — If you plan to contribute or prefer to work directly with the source repository, clone it and run the scripts yourself.  See below.
 
 ### Clone and initialize (contributor/developer path)

--- a/docs/00-prereqs.md
+++ b/docs/00-prereqs.md
@@ -32,16 +32,16 @@ The lab requires several ISO and installer files that are **not included** in th
 
 - pfSense CE ISO (AMD64)
 - Ubuntu Server 22.04 ISO (AMD64)
-- Windows 11 Evaluation ISO (English)
+- Windows 11 ISO (English)
 - Nessus Essentials `.deb` (Ubuntu AMD64)
 
-You may download these yourself and place them into `E:\SOC-9000\isos`, **or** you can use the helper script to fetch them automatically.  From the repo root run:
+You may download these yourself and place them into `E:\SOC-9000\isos`, **or** you can use the helper script to fetch Ubuntu automatically and open vendor pages for the rest.  From the repo root run:
 
 ```powershell
 pwsh -File .\scripts\download-isos.ps1
 ```
 
-The script checks for existing files and downloads what’s missing, using known good URLs from the vendors.  Feel free to edit `scripts/download-isos.ps1` if you need to update the URLs.
+The script downloads Ubuntu automatically and opens vendor pages for pfSense, Windows 11, and Nessus so you can fetch them manually. pfSense and Nessus require free accounts; using a disposable email is fine. Files can keep their vendor‑supplied names—the installer detects them automatically. Feel free to edit `scripts/download-isos.ps1` if you need to update the URLs.
 
 ## Install prerequisites
 

--- a/docs/BEGINNER-GUIDE.md
+++ b/docs/BEGINNER-GUIDE.md
@@ -42,11 +42,11 @@ You need enough CPU and memory to run several VMs concurrently.  More is always 
 The lab requires several OS images that are **not** stored in this repository.  A helper script is provided to download them for you:
 
 - **Ubuntu 22.04 ISO** – base for ContainerHost and WSL
-- **Windows 11 Evaluation ISO** – base for the victim VM (trial license)
+- **Windows 11 ISO** – base for the victim VM
 - **pfSense ISO** – firewall/router installer
 - **Nessus Essentials (.deb)** – optional for the Nessus VM path
 
-To download these automatically:
+To fetch the images:
 
 1. Open **PowerShell as Administrator** and navigate to your cloned repo:
    ```powershell
@@ -57,7 +57,7 @@ To download these automatically:
    pwsh -File .\scripts\download-isos.ps1
    ```
 
-The script checks your `isos` folder (`E:\SOC-9000\isos` by default), downloads each file if it does not already exist, and verifies basic properties (size and type).  Direct download URLs are embedded in the script; you can update them if new releases become available.  If you prefer to supply your own ISOs, you can place them in the folder and the script will skip downloading.
+The script checks your `isos` folder (`E:\SOC-9000\isos` by default), downloads Ubuntu automatically if it is missing, and opens vendor pages for pfSense, Windows 11, and Nessus so you can download them manually. pfSense and Nessus require free accounts; a burner email works fine. You can keep the original file names—the installer detects them automatically. If you prefer to supply your own files, place them in the folder and the script will skip them.
 
 ### One‑click installer
 

--- a/docs/iso-downloads.md
+++ b/docs/iso-downloads.md
@@ -24,7 +24,7 @@ identity.  After logging in:
 1. Navigate to <https://www.pfsense.org/download/>.
 2. Select the **pfSense CE** version and architecture (e.g. `amd64` installer).
 3. Choose a mirror close to your location and download the ISO.
-4. Save the file into your `ISO_DIR` as **`pfsense.iso`** (rename if needed).
+4. Save the file into your `ISO_DIR`. The installer automatically detects any pfSense ISO file name.
 
 If automatic downloading fails, the installer will open the download page for
 you and pause.  Place the ISO into the `isos` directory and then resume the
@@ -47,10 +47,7 @@ official Windows 11 ISO manually:
    24 hours.  Sign in with your Microsoft account if prompted.
 4. Download the ISO.  The file name may differ from the default
    `win11-eval.iso`, for example `Win11_23H2_EnglishInternational_x64.iso`.
-5. Copy or rename the file into your `ISO_DIR`.  The installer will attempt to
-   detect any ISO whose name contains "win" and "11" automatically.  If
-   multiple Windows 11 ISOs exist, rename the one you intend to use to
-   `win11-eval.iso` for clarity.
+5. Copy the file into your `ISO_DIR`. The installer detects any ISO whose name contains "win" and "11" automatically. If multiple Windows 11 ISOs exist, remove the extras or rename the one you intend to use for clarity.
 
 ## Nessus Essentials
 
@@ -64,16 +61,12 @@ address if you prefer not to receive marketing emails.  To download the
    address can be used.
 2. After registration, follow the download link provided and select the Linux
    (Ubuntu/Debian) installer.
-3. Save the file into your `ISO_DIR` as **`nessus_latest_amd64.deb`** (rename
-   the file if the vendor uses a versioned name).
+3. Save the file into your `ISO_DIR`. The installer automatically detects Nessus packages that include `amd64` in the name.
 
 ## Summary
 
 - Place all downloaded files into the directory specified by the `ISO_DIR`
   environment variable (default: `E:\\SOC-9000-Pre-Install\\isos`).
-- Ensure the file names match those expected by the installer (`pfsense.iso`,
-  `win11-eval.iso`, and `nessus_latest_amd64.deb`).  The installer will
-  automatically detect Windows 11 ISOs with other names, but renaming to the
-  expected name avoids ambiguity.
+- The installer automatically detects pfSense, Windows 11, and Nessus files based on their content; renaming is optional.
 - After downloading and copying the files, re‑run the installer with the
   `-SkipPrereqs` option to continue the lab bring‑up.

--- a/orchestration/apply-containerhost-netplan.ps1
+++ b/orchestration/apply-containerhost-netplan.ps1
@@ -9,10 +9,10 @@ $ErrorActionPreference="Stop"
 function Load-Env($p=".env"){
   if(!(Test-Path $p)){ throw ".env not found" }
   Get-Content $p | ? {$_ -and $_ -notmatch '^\s*#'} | % {
-    if($_ -match '^\s*([^=]+)=(.*)$'){
-      $name = $matches[1].Trim()
-      $env:${name} = $matches[2].Trim()
-    }
+      if($_ -match '^\s*([^=]+)=(.*)$'){
+        $name = $matches[1].Trim()
+        Set-Item -Path "Env:$name" -Value ($matches[2].Trim())
+      }
   }
 }
 

--- a/orchestration/wire-networks.ps1
+++ b/orchestration/wire-networks.ps1
@@ -10,24 +10,25 @@ $ErrorActionPreference = "Stop"
 function Load-Env($path=".env"){
   if(!(Test-Path $path)){ throw ".env not found. Copy .env.example to .env first." }
   Get-Content $path | ? {$_ -and $_ -notmatch '^\s*#'} | % {
-    if ($_ -match '^\s*([^=]+)=(.*)$'){
-      $name = $matches[1].Trim()
-      $env:${name} = $matches[2].Trim()
-    }
+      if ($_ -match '^\s*([^=]+)=(.*)$'){
+        $name = $matches[1].Trim()
+        Set-Item -Path "Env:$name" -Value ($matches[2].Trim())
+      }
   }
 }
 
 function Edit-Vmx($vmxPath, [hashtable]$pairs){
   if(!(Test-Path $vmxPath)){ throw "VMX not found: $vmxPath" }
   $text = Get-Content $vmxPath -Raw
-  foreach($k in $pairs.Keys){
-    $v = $pairs[$k]
-    if($text -match "(?m)^\Q$k\E\s*=\s*\".*?\""){
-      $text = [regex]::Replace($text, "(?m)^\Q$k\E\s*=\s*\".*?\"", "$k = \"$v\"")
-    } else {
-      $text += "`n$k = \"$v\""
+    foreach($k in $pairs.Keys){
+      $v = $pairs[$k]
+      $pattern = "(?m)^" + [regex]::Escape($k) + "\s*=\s*\".*?\""
+      if($text -match $pattern){
+        $text = [regex]::Replace($text, $pattern, "$k = \"$v\"")
+      } else {
+        $text += "`n$k = \"$v\""
+      }
     }
-  }
   Set-Content -Path $vmxPath -Value $text -NoNewline
 }
 

--- a/packer/ubuntu-container/ubuntu-container.pkr.hcl
+++ b/packer/ubuntu-container/ubuntu-container.pkr.hcl
@@ -7,13 +7,40 @@ packer {
   }
 }
 
-variable "iso_path"     { type = string, default = "E:/SOC-9000/isos/ubuntu-22.04.iso" }
-variable "ssh_username" { type = string, default = "labadmin" }
-variable "ssh_password" { type = string, default = "ChangeMe_S0C9000!" }
-variable "vm_name"      { type = string, default = "container-host" }
-variable "disk_size_mb" { type = number, default = 100000 }
-variable "cpus"         { type = number, default = 6 }
-variable "memory_mb"    { type = number, default = 16384 }
+variable "iso_path" {
+  type    = string
+  default = "E:/SOC-9000/isos/ubuntu-22.04.iso"
+}
+
+variable "ssh_username" {
+  type    = string
+  default = "labadmin"
+}
+
+variable "ssh_password" {
+  type    = string
+  default = "ChangeMe_S0C9000!"
+}
+
+variable "vm_name" {
+  type    = string
+  default = "container-host"
+}
+
+variable "disk_size_mb" {
+  type    = number
+  default = 100000
+}
+
+variable "cpus" {
+  type    = number
+  default = 6
+}
+
+variable "memory_mb" {
+  type    = number
+  default = 16384
+}
 
 source "vmware-iso" "ubuntu2204" {
   vm_name              = var.vm_name

--- a/packer/windows-victim/windows.pkr.hcl
+++ b/packer/windows-victim/windows.pkr.hcl
@@ -7,12 +7,35 @@ packer {
   }
 }
 
-variable "iso_path"       { type = string, default = "E:/SOC-9000/isos/win11-eval.iso" }
-variable "vm_name"        { type = string, default = "victim-win" }
-variable "admin_password" { type = string, default = "ChangeMe_S0C9000!" }
-variable "disk_size_mb"   { type = number, default = 80000 }
-variable "cpus"           { type = number, default = 4 }
-variable "memory_mb"      { type = number, default = 8192 }
+variable "iso_path" {
+  type    = string
+  default = "E:/SOC-9000/isos/win11-eval.iso"
+}
+
+variable "vm_name" {
+  type    = string
+  default = "victim-win"
+}
+
+variable "admin_password" {
+  type    = string
+  default = "ChangeMe_S0C9000!"
+}
+
+variable "disk_size_mb" {
+  type    = number
+  default = 80000
+}
+
+variable "cpus" {
+  type    = number
+  default = 4
+}
+
+variable "memory_mb" {
+  type    = number
+  default = 8192
+}
 
 source "vmware-iso" "win11" {
   vm_name              = var.vm_name

--- a/scripts/build-packer.ps1
+++ b/scripts/build-packer.ps1
@@ -1,13 +1,24 @@
-# Build Ubuntu ContainerHost and Windows victim
-$ErrorActionPreference = "Stop"
+# Build Ubuntu ContainerHost and Windows victim with dynamic ISO paths
+$ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+
+# Read .env for ISO_DIR and filenames
+$envPath  = Join-Path (Split-Path $PSScriptRoot -Parent) '.env'
+$envLines = Get-Content $envPath | Where-Object { $_ -and $_ -notmatch '^\s*#' }
+$isoDir      = ($envLines | Where-Object { $_ -match '^ISO_DIR=' })      -replace '^ISO_DIR=', ''
+$isoUbuntu   = ($envLines | Where-Object { $_ -match '^ISO_UBUNTU=' })   -replace '^ISO_UBUNTU=', ''
+$isoWindows  = ($envLines | Where-Object { $_ -match '^ISO_WINDOWS=' })  -replace '^ISO_WINDOWS=', ''
+
+$ubuntuPath  = Join-Path $isoDir $isoUbuntu
+$windowsPath = Join-Path $isoDir $isoWindows
+
 pushd packer\ubuntu-container
 packer init .
-packer build -force .
+packer build -force -var "iso_path=$ubuntuPath" .
 popd
 
 pushd packer\windows-victim
 packer init .
-packer build -force .
+packer build -force -var "iso_path=$windowsPath" .
 popd
 
-Write-Host "Packer builds complete. Check E:\SOC-9000\artifacts\* for VMX files."
+Write-Host "Packer builds complete. Check $isoDir\..\artifacts\* for VMX files."

--- a/scripts/deploy-nessus-essentials.ps1
+++ b/scripts/deploy-nessus-essentials.ps1
@@ -1,11 +1,11 @@
 # Deploy Nessus Essentials on k3s and add a hosts entry.
 param(
-  [string]$Ns = "soc",
-  [string]$LbIp = "172.22.10.61",
-  [string]$Host = "nessus.lab.local"
+  [string]$Ns      = "soc",
+  [string]$LbIp    = "172.22.10.61",
+  [string]$HostName = "nessus.lab.local"
 )
 $ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
-function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
+function K { kubectl $args }
 
 # Ensure namespace exists
 K get ns $Ns 2>$null | Out-Null; if ($LASTEXITCODE -ne 0) { K create ns $Ns | Out-Null }
@@ -30,10 +30,10 @@ if (-not $ip) { $ip = $LbIp }
 $hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
 $orig = Get-Content $hosts
 $filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
-$block = @("# SOC-9000 BEGIN", "$ip $Host", "# SOC-9000 END")
+$block = @("# SOC-9000 BEGIN", "$ip $HostName", "# SOC-9000 END")
 Set-Content -Path $hosts -Value ($filtered + $block) -Force
 
-Write-Host "`nOpen: https://$Host:8834"
+Write-Host "`nOpen: https://$HostName:8834"
 Write-Host "Setup steps:"
 Write-Host "  1) Choose 'Nessus Essentials', request/enter activation code."
 Write-Host "  2) Create the admin account."

--- a/scripts/download-isos.ps1
+++ b/scripts/download-isos.ps1
@@ -3,14 +3,7 @@ param(
     [string]$IsoDir,
 
     # Optional overrides; can also be provided via .env
-    [string]$UbuntuUrl  = $null,
-    # pfSense ISO: if provided, the script will attempt to download from this URL.  If omitted,
-    # the pfSense download page will be opened directly for a manual download.
-    [string]$PfSenseUrl = $null,
-    # Windows 11 ISO: provide a direct download URL to attempt an automated fetch.
-    [string]$Win11Url   = $null,
-    # Nessus package: provide a direct download URL to attempt an automated fetch.
-    [string]$NessusUrl  = $null
+    [string]$UbuntuUrl  = $null
 )
 
 Set-StrictMode -Version Latest
@@ -45,13 +38,9 @@ New-Item -ItemType Directory -Path $IsoDir -Force | Out-Null
 # Defaults (can be overridden by params or .env)
 if (-not $UbuntuUrl)  { $UbuntuUrl  = 'https://releases.ubuntu.com/jammy/ubuntu-22.04.5-live-server-amd64.iso' }
 
-# pfSense downloads previously attempted to use multiple mirrors to fetch the ISO.
-# In practice these URLs often fail due to DNS or certificate issues.  To simplify
-# the user experience, we no longer try a series of mirrors.  Instead, if a
-# specific URL is provided via -PfSenseUrl we will attempt to download from it;
-# otherwise we immediately open the pfSense vendor page so the user can choose
-# their nearest mirror manually.  See the pfSense documentation for details.
-$pfMirrors = @()
+# pfSense, Windows 11 and Nessus require gated or expiring URLs.  We no longer
+# attempt automatic downloads for these files; instead the script immediately
+# opens the vendor page so the user can obtain the latest image manually.
 
 $AllowedIsoContentTypes = @(
   'application/x-iso9660-image','application/octet-stream',
@@ -69,11 +58,19 @@ function Invoke-Download {
     for ($i=1; $i -le $MaxTries; $i++) {
         try {
             Write-Info "[*] Downloading $(Split-Path -Leaf $OutFile) (try $i/$MaxTries)..."
-            $resp = Invoke-WebRequest -Uri $Uri -OutFile $OutFile -Headers $ua -TimeoutSec $TimeoutSec -UseBasicParsing -ErrorAction Stop
-            $ct = $resp.Headers['Content-Type']
-            if ($ct -and -not ($AllowedIsoContentTypes -contains $ct)) {
-                Write-Warn "Downloaded but content-type '$ct' is unusual for ISO; keeping file."
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -Headers $ua -TimeoutSec $TimeoutSec -UseBasicParsing -ErrorAction Stop
+
+            # Best-effort content-type check using a lightweight HEAD request
+            try {
+                $head = Invoke-WebRequest -Method Head -Uri $Uri -Headers $ua -TimeoutSec 30 -UseBasicParsing -ErrorAction Stop
+                $ct = $head.Headers['Content-Type']
+                if ($ct -and -not ($AllowedIsoContentTypes -contains $ct)) {
+                    Write-Warn "Downloaded but content-type '$ct' is unusual for ISO; keeping file."
+                }
+            } catch {
+                Write-Warn "Could not inspect headers: $($_.Exception.Message)"
             }
+
             if ((Test-Path $OutFile) -and ((Get-Item $OutFile).Length -gt 10MB)) {
                 $mb = [math]::Round((Get-Item $OutFile).Length/1MB,1)
                 Write-Good "[+] Saved $(Split-Path -Leaf $OutFile) ($mb MB)"
@@ -101,65 +98,60 @@ function Ensure-FromUrls {
     return $false
 }
 
-function Ensure-OrOpenVendor {
+function Find-FirstMatchingFile {
     param(
-        [Parameter(Mandatory)] [string]$OutFile,
-        [string]$UrlIfAny,
-        [string]$VendorPage
+        [Parameter(Mandatory)] [string]$Dir,
+        [Parameter(Mandatory)] [string[]]$Patterns
     )
-    # If the file already exists, nothing to do
-    if (Test-Path $OutFile) {
-        Write-Good "[=] Exists: $(Split-Path -Leaf $OutFile)"
-        return
+    if (-not (Test-Path $Dir)) { return $null }
+    $files = Get-ChildItem -Path $Dir -File -ErrorAction SilentlyContinue
+    foreach ($p in $Patterns) {
+        $m = $files | Where-Object { $_.Name -match $p } | Select-Object -First 1
+        if ($m) { return $m }
     }
-    # Attempt direct download if a URL override was provided
-    if ($UrlIfAny) {
-        if (Invoke-Download -Uri $UrlIfAny -OutFile $OutFile) { return }
-    }
-    # Fall back to manual download: open the vendor page and defer prompting
-    Write-Warn "$(Split-Path -Leaf $OutFile) requires a gated or expiring URL. Opening vendor page…"
-    if ($VendorPage) {
-        try { Start-Process $VendorPage } catch { Write-Warn "Could not open browser: $($_.Exception.Message)" }
-    }
-    Write-Info "Please download manually and place it at: $OutFile"
-    # Record that a manual download is needed; the unified prompt at the end
-    # will wait for the user to press Enter once all manual downloads are complete.
+    return $null
+}
+
+function Open-VendorPage {
+    param(
+        [Parameter(Mandatory)] [string]$VendorPage,
+        [Parameter(Mandatory)] [string]$DisplayName
+    )
+    Write-Warn "$DisplayName requires manual download. Opening vendor page…"
+    try { Start-Process $VendorPage } catch { Write-Warn "Could not open browser: $($_.Exception.Message)" }
+    Write-Info "Save the file into $IsoDir with its original name."
     $script:manualFilesNeeded = $true
 }
 
 # Targets
 $UbuntuIso  = Join-Path $IsoDir 'ubuntu-22.04.iso'
-$PfSenseIso = Join-Path $IsoDir 'pfsense.iso'
-$Win11Iso   = Join-Path $IsoDir 'win11-eval.iso'
-$NessusDeb  = Join-Path $IsoDir 'nessus_latest_amd64.deb'
 
 # Ubuntu (static)
 Ensure-FromUrls -OutFile $UbuntuIso -Urls @($UbuntuUrl) | Out-Null
 
-# pfSense: open vendor page for manual download by default.  If a PfSenseUrl
-# override is supplied, attempt a direct download; otherwise open the pfSense
-# download page for the user.
-Ensure-OrOpenVendor -OutFile $PfSenseIso -UrlIfAny $PfSenseUrl -VendorPage 'https://www.pfsense.org/download/'
+# pfSense: detect existing file or open vendor page
+$pf = Find-FirstMatchingFile -Dir $IsoDir -Patterns @('(?i)(pfsense|netgate).*\.iso$')
+if ($pf) {
+    Write-Good "[=] Exists: $($pf.Name)"
+} else {
+    Open-VendorPage -VendorPage 'https://www.pfsense.org/download/' -DisplayName 'pfSense ISO (Netgate account required; burner email OK)'
+}
 
-# Windows 11 ISO (International)
-# The official Microsoft download page requires you to choose an edition and language
-# and provides a time-limited URL for the ISO.  If you provide a direct URL via
-# -Win11Url, the installer will attempt to download it.  Otherwise the script
-# opens the official download page where you can select "Windows 11" and language
-# "English International" (x64) and save the ISO.  Once downloaded, copy or
-# rename the file into ISO_DIR.  If you download a file with a different name
-# (e.g. Win11_23H2_EnglishInternational_x64.iso), simply rename it to match
-# $Win11Iso or adjust your .env ISO_DIR accordingly.
-Ensure-OrOpenVendor -OutFile $Win11Iso -UrlIfAny $Win11Url -VendorPage 'https://www.microsoft.com/de-de/software-download/windows11'
+# Windows 11 ISO
+$win = Find-FirstMatchingFile -Dir $IsoDir -Patterns @('(?i).*win(dows)?[^\\w]*11.*\.iso$')
+if ($win) {
+    Write-Good "[=] Exists: $($win.Name)"
+} else {
+    Open-VendorPage -VendorPage 'https://www.microsoft.com/de-de/software-download/windows11' -DisplayName 'Windows 11 ISO'
+}
 
-# Nessus (gated)
-# Tenable’s Nessus downloads require you to sign up for a Nessus Essentials key
-# before the download link becomes available.  If no direct URL is provided
-# via -NessusUrl, the installer will open the Nessus Essentials registration
-# page.  Register with a disposable email address, obtain the download link and
-# save the .deb package into your ISO_DIR.  After placing the file, press
-# Enter when prompted to continue.
-Ensure-OrOpenVendor -OutFile $NessusDeb -UrlIfAny $NessusUrl -VendorPage 'https://www.tenable.com/products/nessus/nessus-essentials'
+# Nessus package
+$nes = Find-FirstMatchingFile -Dir $IsoDir -Patterns @('(?i)^nessus.*amd64.*\.deb$')
+if ($nes) {
+    Write-Good "[=] Exists: $($nes.Name)"
+} else {
+    Open-VendorPage -VendorPage 'https://www.tenable.com/products/nessus/nessus-essentials' -DisplayName 'Nessus Essentials .deb (registration required; burner email OK)'
+}
 
 # Unified prompt: if any manual downloads were required, prompt once at the end
 if ($script:manualFilesNeeded) {

--- a/scripts/expose-wazuh-manager.ps1
+++ b/scripts/expose-wazuh-manager.ps1
@@ -1,11 +1,15 @@
 # Expose wazuh-manager via MetalLB (1514/1515 TCP). Auto-detects selector labels.
 param([string]$Ns="soc",[string]$LbIp="172.22.10.62")
 $ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
-function K { param([Parameter(ValueFromRemainingArguments)]$a) kubectl @a }
+function K { kubectl $args }
 
 if (Test-Path ".env") {
-  (Get-Content .env | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
-    if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+  (Get-Content .env | ? {$_ -and $_ -notmatch '^\s*#'}) | ForEach-Object {
+    if ($_ -match '^\s*([^=]+)=(.*)$'){
+      $name  = $matches[1].Trim()
+      $value = $matches[2].Trim()
+      Set-Item -Path "Env:$name" -Value $value
+    }
   }
   if ($env:WAZUH_MANAGER_LB_IP) { $LbIp = $env:WAZUH_MANAGER_LB_IP }
 }

--- a/scripts/gen-ssl.ps1
+++ b/scripts/gen-ssl.ps1
@@ -26,7 +26,7 @@ $SAN | Set-Content -Path san.cnf -Encoding ascii
 & openssl x509 -req -in wildcard.$($Domain).csr -CA lab-local-ca.crt -CAkey lab-local-ca.key -CAcreateserial -out wildcard.$($Domain).crt -days 825 -sha256 -extfile san.cnf
 
 popd
-Write-Host "Certs ready in $OutDir:"
+Write-Host "Certs ready in ${OutDir}:"
 Get-ChildItem $OutDir | Select Name,Length | Format-Table
 Write-Host "Import CA into Windows Trusted Root:"
 Write-Host "  certutil -addstore -f -enterprise -user Root `"$OutDir\lab-local-ca.crt`""

--- a/scripts/host-prepare.ps1
+++ b/scripts/host-prepare.ps1
@@ -52,11 +52,11 @@ Write-Host "`nNext steps:"
    - VMnet21 : Host-only 172.22.20.0/24, DHCP OFF
    - VMnet22 : Host-only 172.22.30.0/24, DHCP OFF
    - VMnet23 : Host-only 172.22.40.0/24, DHCP OFF"
-"2) Download to $IsoDir:
-   - pfSense CE (AMD64)  -> $(Join-Path $IsoDir 'pfsense.iso')
-   - Ubuntu 22.04 (AMD64)-> $(Join-Path $IsoDir 'ubuntu-22.04.iso')
-   - Windows 11 Eval     -> $(Join-Path $IsoDir 'win11-eval.iso')
+"2) Place downloads in ${IsoDir}:
+   - pfSense CE ISO (Netgate account required)
+   - Ubuntu 22.04 (AMD64) -> $(Join-Path $IsoDir 'ubuntu-22.04.iso')
+   - Windows 11 ISO (any filename)
    - Nessus Essentials .deb (Ubuntu AMD64)"
-"   (Tip: run scripts\download-isos.ps1 to download these automatically)"
+"   (Tip: run scripts\download-isos.ps1 to fetch Ubuntu automatically and open vendor pages for the rest)"
 "3) Ensure SSH key at %USERPROFILE%\.ssh\id_ed25519 (or create it)."
 "4) (Optional) Copy SSH key into WSL: scripts\copy-ssh-key-to-wsl.ps1"

--- a/scripts/hosts-refresh.ps1
+++ b/scripts/hosts-refresh.ps1
@@ -1,6 +1,6 @@
 # Rebuild a single SOC-9000 hosts block based on current cluster state
 $ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
-function K { param([Parameter(ValueFromRemainingArguments)]$a) kubectl @a }
+function K { kubectl $args }
 
 $entries = @()
 # Traefik (k3s default namespace)

--- a/scripts/install-prereqs.ps1
+++ b/scripts/install-prereqs.ps1
@@ -8,6 +8,13 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Refresh PATH from machine and user scopes so newly installed tools are
+# immediately available without restarting PowerShell.
+function Refresh-Path {
+    $env:Path = [System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' +
+                [System.Environment]::GetEnvironmentVariable('Path','User')
+}
+
 $winget = Get-Command winget -ErrorAction SilentlyContinue
 if (-not $winget) {
     Write-Error "winget is not installed or not in PATH. Cannot install prerequisites."
@@ -21,6 +28,7 @@ if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
     Write-Host "PowerShell 7 not found. Installing via winget..." -ForegroundColor Cyan
     try {
         winget install --id Microsoft.PowerShell --source winget --accept-package-agreements --accept-source-agreements
+        Refresh-Path
         if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) {
             Write-Warning "winget returned exit code $LASTEXITCODE for PowerShell 7"
             $failed = $true
@@ -38,6 +46,7 @@ if (-not (Get-Command packer -ErrorAction SilentlyContinue)) {
     Write-Host "Packer not found. Installing via winget..." -ForegroundColor Cyan
     try {
         winget install --id HashiCorp.Packer --accept-package-agreements --accept-source-agreements
+        Refresh-Path
     } catch {
         Write-Warning "Failed to install Packer via winget. You may need to install it manually."
     }
@@ -50,6 +59,7 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     Write-Host "Git not found. Installing via winget..." -ForegroundColor Cyan
     try {
         winget install --id Git.Git --source winget --accept-package-agreements --accept-source-agreements
+        Refresh-Path
         if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) {
             Write-Warning "winget returned exit code $LASTEXITCODE for Git"
             $failed = $true


### PR DESCRIPTION
## Summary
- load `.env` using script-relative paths for Packer builds and escape VMX keys when wiring networks
- avoid parser errors in SSL generation and Wazuh/Nessus helpers by quoting variables and using `Set-Item` for environment variables
- simplify `kubectl` wrapper functions across host management scripts

## Testing
- `npx -y markdownlint-cli README.md docs/00-prereqs.md docs/BEGINNER-GUIDE.md docs/iso-downloads.md`
- `npm audit --production`
- `pwsh -NoProfile -File scripts/smoke-test.ps1` *(fails: command not found; `apt-get install -y powershell` unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689c95df1a5c832d895d3fa21a029933