### PR TITLE
feat: automate VMware network setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ sudo apt update && sudo apt -y install ansible git jq curl
 
 ### VMware nets (host-only)
 
-Created automatically by `scripts/host-prepare.ps1` (uses VMware's `vmnetcfgcli.exe`):
+Created and verified automatically by `scripts/host-prepare.ps1` (uses VMware's `vnetlib.exe`—or `vmnetcfgcli.exe` if present—when available). If the utilities are missing or configuration fails, the script launches **Virtual Network Editor** (`vmnetcfg.exe`) and waits for confirmation before continuing:
 
 - VMnet20 = 172.22.10.0/24 (MGMT)
 - VMnet21 = 172.22.20.0/24 (SOC)

--- a/docs/00-prereqs.md
+++ b/docs/00-prereqs.md
@@ -18,7 +18,7 @@ Goal: Prepare Windows 11 + VMware Workstation for a pfSense-routed, k3s-managed,
 
 ## Networks (Virtual Network Editor)
 
-The `scripts/host-prepare.ps1` helper uses VMware's `vmnetcfgcli.exe` to create the required VMnets automatically. After running the script, verify the adapters in **Virtual Network Editor** if needed:
+The `scripts/host-prepare.ps1` helper uses VMware's `vnetlib.exe` (or `vmnetcfgcli.exe` if available) to create and verify the required VMnets automatically. If the tools are missing or configuration fails, it launches **Virtual Network Editor** (`vmnetcfg.exe`) and pauses until you confirm the networks are ready:
 
 - `VMnet8` — NAT (DHCP ON)
 - `VMnet20` — MGMT `172.22.10.0/24` (DHCP OFF)
@@ -69,14 +69,16 @@ These scripts are especially useful when preparing a GitHub release.
 
 ## SSH key
 
-Generate or reuse:
+`scripts/host-prepare.ps1` ensures `%USERPROFILE%\.ssh\id_ed25519` exists, generating a new key if needed and printing its location. To copy the key into WSL (recommended):
+
+```powershell
+pwsh -File .\scripts\copy-ssh-key-to-wsl.ps1
+```
+
+To create a custom key manually:
 
 ```powershell
 ssh-keygen -t ed25519 -C "soc-9000" -f $env:USERPROFILE\.ssh\id_ed25519
-
-Copy into WSL (recommended):
-
-pwsh -File .\scripts\copy-ssh-key-to-wsl.ps1
 ```
 
 ## Quick start

--- a/docs/02-packer.md
+++ b/docs/02-packer.md
@@ -15,3 +15,5 @@ pwsh -ExecutionPolicy Bypass -File .\scripts\build-packer.ps1
 # or run each packer subdir manually
 ```
 Artifacts are written to E:\SOC-9000\artifacts\<vm-name>\*.vmx.
+
+> The build runs headless. Packer briefly exposes a VNC port for automation, but no viewer is required. On typical hardware, the Ubuntu build takes ~10–20 minutes and the Windows build ~30–60 minutes.

--- a/docs/BEGINNER-GUIDE.md
+++ b/docs/BEGINNER-GUIDE.md
@@ -135,7 +135,7 @@ The `init` target copies `.env.example` to `.env`.  Open `.env` in Notepad, adju
 
 ## 7. Verify VMware host‑only networks
 
-Run `pwsh -File .\scripts\host-prepare.ps1` to auto-create the required VMnets (uses `vmnetcfgcli.exe`). After it completes, open **VMware Workstation → Edit → Virtual Network Editor** and confirm the following networks exist:
+Run `pwsh -File .\scripts\host-prepare.ps1` to auto-create and verify the required VMnets (uses `vnetlib.exe`—or `vmnetcfgcli.exe` if available—when possible). If the tools are missing or configuration fails, the script opens **Virtual Network Editor** (`vmnetcfg.exe`) and waits for you to confirm these networks exist:
 
    - `VMnet20` → 172.22.10.0/24 (MGMT)
    - `VMnet21` → 172.22.20.0/24 (SOC)

--- a/docs/quickstart-printable.md
+++ b/docs/quickstart-printable.md
@@ -6,7 +6,7 @@
 
 **ISOs:** ubuntu-22.04.iso, win11-eval.iso, pfsense.iso (+ optional nessus_latest_amd64.deb)
 
-**VMware nets:** VMnet20=172.22.10.0/24, VMnet21=172.22.20.0/24, VMnet22=172.22.30.0/24, VMnet23=172.22.40.0/24, VMnet8=NAT (created by `scripts/host-prepare.ps1`)
+**VMware nets:** VMnet20=172.22.10.0/24, VMnet21=172.22.20.0/24, VMnet22=172.22.30.0/24, VMnet23=172.22.40.0/24, VMnet8=NAT (created & verified by `scripts/host-prepare.ps1`)
 
 **Repo:**
 

--- a/scripts/build-packer.ps1
+++ b/scripts/build-packer.ps1
@@ -1,4 +1,6 @@
-# Build Ubuntu ContainerHost and Windows victim with dynamic ISO paths
+# Build Ubuntu ContainerHost and Windows victim with dynamic ISO paths.
+# Uses Packer's headless vmware-iso builder; a temporary VNC endpoint is printed but no viewer is required.
+# Expect roughly 10–20 minutes for the Ubuntu build and 30–60 minutes for the Windows build on typical hardware.
 $ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
 
 # Read .env for ISO_DIR and filenames

--- a/scripts/host-prepare.ps1
+++ b/scripts/host-prepare.ps1
@@ -26,15 +26,30 @@ $freeGB = if($drive){ [math]::Round($drive.Free/1GB,2) } else { 0 }
 
 # VMware networks required
 $need = "VMnet8","VMnet20","VMnet21","VMnet22","VMnet23"
-$have = Get-NetAdapter -Physical:$false -ErrorAction SilentlyContinue | % Name
-$missing = $need | ? { $_ -notin $have }
+function Get-VMnetNames {
+  Get-NetAdapter -Name 'VMware Network Adapter VMnet*' -Physical:$false -ErrorAction SilentlyContinue |
+    ForEach-Object {
+      if ($_.Name -match '(VMnet\d+)') { $matches[1] }
+    }
+}
+$have = Get-VMnetNames
+$missing = $need | Where-Object { $_ -notin $have }
 
-# Attempt automatic network creation if vmnetcfgcli.exe is available
-$vmnetcfg = FindExe "vmnetcfgcli.exe" @(
+# Attempt automatic network creation if VMware's network utilities are available
+$vmnetcfgcli = FindExe "vmnetcfgcli.exe" @(
   "C:\Program Files (x86)\VMware\VMware Workstation\vmnetcfgcli.exe",
   "C:\Program Files\VMware\VMware Workstation\vmnetcfgcli.exe"
 )
-if ($vmnetcfg -and $missing) {
+$vnetlib = FindExe "vnetlib.exe" @(
+  "C:\Program Files (x86)\VMware\VMware Workstation\vnetlib.exe",
+  "C:\Program Files\VMware\VMware Workstation\vnetlib.exe"
+)
+$editor = FindExe "vmnetcfg.exe" @(
+  "C:\Program Files (x86)\VMware\VMware Workstation\vmnetcfg.exe",
+  "C:\Program Files\VMware\VMware Workstation\vmnetcfg.exe"
+)
+
+if ($missing) {
   $nets = @(
     @{Name='VMnet8';  Type='nat';      Subnet='192.168.37.0'; Dhcp=$true},
     @{Name='VMnet20'; Type='hostonly'; Subnet='172.22.10.0';  Dhcp=$false},
@@ -42,17 +57,55 @@ if ($vmnetcfg -and $missing) {
     @{Name='VMnet22'; Type='hostonly'; Subnet='172.22.30.0';  Dhcp=$false},
     @{Name='VMnet23'; Type='hostonly'; Subnet='172.22.40.0';  Dhcp=$false}
   )
-  foreach ($n in $nets) {
-    if ($missing -contains $n.Name) {
-      try {
-        & $vmnetcfg --add $n.Name --type $n.Type --subnet $n.Subnet --netmask 255.255.255.0 --dhcp ($n.Dhcp ? 'yes' : 'no') 2>$null | Out-Null
-      } catch {
-        Write-Warning "Failed to configure $($n.Name): $($_.Exception.Message)"
+  if ($vnetlib) {
+    function Invoke-VNetLib([string[]]$args) {
+      & $vnetlib -- @args 2>$null | Out-Null
+      if ($LASTEXITCODE -ne 0) { throw "vnetlib $($args -join ' ') failed ($LASTEXITCODE)" }
+    }
+    foreach ($n in $nets) {
+      if ($missing -contains $n.Name) {
+        try {
+          Invoke-VNetLib @("addNetwork", $n.Name)
+          Invoke-VNetLib @("setSubnet", $n.Name, $n.Subnet, "255.255.255.0")
+          Invoke-VNetLib @("setDhcp", $n.Name, ($n.Dhcp ? 'on' : 'off'))
+          Invoke-VNetLib @("setNat", $n.Name, ($n.Type -eq 'nat' ? 'on' : 'off'))
+          Write-Host "Configured $($n.Name) via vnetlib" -ForegroundColor Green
+        } catch {
+          Write-Warning "Failed to configure $($n.Name): $($_.Exception.Message)"
+        }
+      }
+    }
+  } elseif ($vmnetcfgcli) {
+    foreach ($n in $nets) {
+      if ($missing -contains $n.Name) {
+        try {
+          & $vmnetcfgcli --add $n.Name --type $n.Type --subnet $n.Subnet --netmask 255.255.255.0 --dhcp ($n.Dhcp ? 'yes' : 'no') 2>$null | Out-Null
+          Write-Host "Configured $($n.Name) via vmnetcfgcli" -ForegroundColor Green
+        } catch {
+          Write-Warning "Failed to configure $($n.Name): $($_.Exception.Message)"
+        }
       }
     }
   }
-  $have = Get-NetAdapter -Physical:$false -ErrorAction SilentlyContinue | % Name
-  $missing = $need | ? { $_ -notin $have }
+  $have = Get-VMnetNames
+  $missing = $need | Where-Object { $_ -notin $have }
+}
+
+if ($missing) {
+  if ($editor) { Start-Process $editor -Verb runAs }
+  Write-Host "Manual VMware network configuration required:" -ForegroundColor Yellow
+  Write-Host "   - VMnet8  : NAT (DHCP ON)"
+  Write-Host "   - VMnet20 : Host-only 172.22.10.0/24, DHCP OFF"
+  Write-Host "   - VMnet21 : Host-only 172.22.20.0/24, DHCP OFF"
+  Write-Host "   - VMnet22 : Host-only 172.22.30.0/24, DHCP OFF"
+  Write-Host "   - VMnet23 : Host-only 172.22.40.0/24, DHCP OFF"
+  do {
+    $choice = Read-Host "[D]one, let's go / [N]ot working yet, restart later"
+    if ($choice -match '^[Nn]') { Write-Host "Exiting. Re-run after configuring networks."; exit 1 }
+    $have = Get-VMnetNames
+    $missing = $need | Where-Object { $_ -notin $have }
+    if ($missing) { Write-Warning "Still missing: $($missing -join ', ')" }
+  } while ($missing)
 }
 
 # WSL / Ansible (best effort)
@@ -66,6 +119,21 @@ if (-not $wsl) {
 }
 $ans = try { wsl -e bash -lc "ansible --version | head -n1" 2>$null } catch { "" }
 
+# SSH key
+$sshDir = Join-Path $env:USERPROFILE '.ssh'
+$sshKey = Join-Path $sshDir 'id_ed25519'
+if (-not (Test-Path $sshKey)) {
+  try {
+    New-Item -Type Directory -Path $sshDir -Force | Out-Null
+    Write-Host "Generating SSH key at $sshKey" -ForegroundColor Cyan
+    ssh-keygen -t ed25519 -N "" -f $sshKey | Out-Null
+  } catch {
+    Write-Warning "Failed to generate SSH key: $($_.Exception.Message)"
+  }
+} else {
+  Write-Host "SSH key already present at $sshKey" -ForegroundColor DarkGray
+}
+
 # Output
 $rows = @(
  @{Item="Folders"; Detail="$IsoDir, $ArtifactsDir, $TempDir"}
@@ -75,6 +143,7 @@ $rows = @(
  @{Item="VMware nets"; Detail=($(if($missing){ "Missing: "+($missing -join ', ') } else { "OK: VMnet8,20,21,22,23" }))}
  @{Item="WSL"; Detail=($(if($wsl){$wsl.Trim()}else{"Install: wsl --install -d Ubuntu-22.04"}))}
  @{Item="Ansible (WSL)"; Detail=($(if($ans){$ans.Trim()}else{"In WSL: apt install python3-pip python3-venv openssh-client && pip install --user ansible==9.*"}))}
+ @{Item="SSH key"; Detail=($(if(Test-Path $sshKey){$sshKey}else{"MISSING"}))}
 )
 $rows | % { "{0,-16} {1}" -f $_.Item, $_.Detail }
 
@@ -95,7 +164,5 @@ Write-Host "   - Ubuntu 22.04 (AMD64) -> $(Join-Path $IsoDir 'ubuntu-22.04.iso')
 Write-Host "   - Windows 11 ISO (any filename)"
 Write-Host "   - Nessus Essentials .deb (Ubuntu AMD64)"
 Write-Host "   (Tip: run scripts\download-isos.ps1 to fetch Ubuntu automatically and open vendor pages for the rest)"
-$step++
-Write-Host "${step}) Ensure SSH key at %USERPROFILE%\.ssh\id_ed25519 (or create it)."
 $step++
 Write-Host "${step}) (Optional) Copy SSH key into WSL: scripts\copy-ssh-key-to-wsl.ps1"

--- a/scripts/lab-up.ps1
+++ b/scripts/lab-up.ps1
@@ -1,6 +1,10 @@
 # End-to-end bring-up for SOC-9000
 $ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
-function Run($p){ Write-Host "`n== $p" -ForegroundColor Cyan; & pwsh -NoProfile -ExecutionPolicy Bypass -File $p }
+function Run($p){
+  Write-Host "`n== $p" -ForegroundColor Cyan
+  & pwsh -NoProfile -ExecutionPolicy Bypass -File $p
+  if ($LASTEXITCODE -ne 0) { throw "Script $p exited with code $LASTEXITCODE" }
+}
 
 # 0) Env + preflight
 if (!(Test-Path ".env")) { Copy-Item .env.example .env -Force; throw "Edit .env then re-run." }


### PR DESCRIPTION
## Summary
- pass discrete arguments to vnetlib for reliable VMnet creation and fall back to vmnetcfgcli when needed
- document that host preparation prefers vnetlib/vmnetcfgcli and only launches vmnetcfg.exe if automation fails
- note VNC port and expected build times in Packer build helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm audit`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689cb6748dd0832d817287b6c8c6fa2f