### PR TITLE
feat: add vmware network automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pwsh -File .\scripts\lab-up.ps1    # end-to-end bring-up (VMs, k3s, apps, teleme
 pwsh -File .\scripts\lab-status.ps1
 ```
 
-Before building the installer script, ensure Git and PowerShell 7 are installed:
+Before building the installer script, ensure Git, PowerShell 7, Packer, and kubectl are installed:
 
 ```powershell
 pwsh -File .\scripts\install-prereqs.ps1
@@ -79,6 +79,17 @@ Validate that script paths resolve correctly without any network activity:
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/smoke-test.ps1
 ```
+
+### Networking
+
+Set up and validate VMware virtual networks:
+
+```powershell
+pwsh -File .\scripts\configure-vmnet.ps1
+pwsh -File .\scripts\verify-networking.ps1
+```
+
+`configure-vmnet.ps1` creates or updates VMnet8 and VMnet20–23 with the correct subnets. `verify-networking.ps1` performs quick assertions and reports success when adapters, services, and hosts entries look good.
 
 During the bring-up process you will still perform a short manual pfSense install (Chunk 3); the scripts then auto‑configure it.
 

--- a/scripts/configure-vmnet.ps1
+++ b/scripts/configure-vmnet.ps1
@@ -1,0 +1,124 @@
+# Configure VMware VMnet adapters for SOC-9000
+[CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+param()
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not $IsWindows) {
+    throw 'configure-vmnet.ps1 can only run on Windows.'
+}
+
+function Test-Admin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $p = New-Object Security.Principal.WindowsPrincipal $id
+    return $p.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+}
+
+function Find-Exe {
+    param(
+        [string]$Name,
+        [string[]]$Candidates
+    )
+    foreach ($c in $Candidates) {
+        if (Test-Path $c) { return $c }
+    }
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    return $null
+}
+
+function Invoke-External {
+    param(
+        [string]$File,
+        [string[]]$Arguments
+    )
+    Write-Verbose "Running: $File $Arguments"
+    & $File @Arguments 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command '$File $Arguments' failed with exit code $LASTEXITCODE"
+    }
+}
+
+if (-not (Test-Admin)) {
+    Write-Error 'Run as administrator. Hint: Start-Process pwsh -Verb RunAs scripts\configure-vmnet.ps1'
+    exit 1
+}
+
+$cli = Find-Exe 'vnetlib64.exe' @(
+    'C:\Program Files (x86)\VMware\VMware Workstation\vnetlib64.exe',
+    'C:\Program Files\VMware\VMware Workstation\vnetlib64.exe'
+)
+$useVmnetcfg = $false
+if (-not $cli) {
+    $cli = Find-Exe 'vmnetcfgcli.exe' @(
+        'C:\Program Files (x86)\VMware\VMware Workstation\vmnetcfgcli.exe',
+        'C:\Program Files\VMware\VMware Workstation\vmnetcfgcli.exe'
+    )
+    if ($cli) { $useVmnetcfg = $true }
+}
+if (-not $cli) {
+    throw 'VMware network CLI not found. Open Workstation → Edit → Virtual Network Editor → Install'
+}
+
+$nets = @(
+    @{Name='vmnet8';  Type='nat';      Subnet='192.168.37.0'; Dhcp=$true},
+    @{Name='vmnet20'; Type='hostonly'; Subnet='172.22.10.0'; Dhcp=$false},
+    @{Name='vmnet21'; Type='hostonly'; Subnet='172.22.20.0'; Dhcp=$false},
+    @{Name='vmnet22'; Type='hostonly'; Subnet='172.22.30.0'; Dhcp=$false},
+    @{Name='vmnet23'; Type='hostonly'; Subnet='172.22.40.0'; Dhcp=$false}
+)
+
+function Get-NetworkInfo {
+    param([string]$Name)
+    try {
+        & $cli -- getvnet $Name 2>$null
+    } catch { return '' }
+}
+
+foreach ($n in $nets) {
+    if ($PSCmdlet.ShouldProcess($n.Name, 'configure')) {
+        if (-not (Get-NetworkInfo $n.Name)) {
+            # create network
+            if ($useVmnetcfg) {
+                Invoke-External $cli @('--add',$n.Name,'--type',$n.Type,'--subnet',$n.Subnet,'--netmask','255.255.255.0','--dhcp',($n.Dhcp?'yes':'no'))
+            } else {
+                Invoke-External $cli @('--','addNetwork', $n.Name)
+            }
+        }
+        if (-not $useVmnetcfg) {
+            Invoke-External $cli @('--','setSubnet',$n.Name,$n.Subnet,'255.255.255.0')
+            Invoke-External $cli @('--','setDhcp',$n.Name,($n.Dhcp?'on':'off'))
+            if ($n.Type -eq 'nat') {
+                Invoke-External $cli @('--','setNat',$n.Name,'on')
+            } else {
+                Invoke-External $cli @('--','setNat',$n.Name,'off')
+            }
+            Invoke-External $cli @('--','updateAdapter',$n.Name)
+        }
+        if ($useVmnetcfg) {
+            # vmnetcfgcli already applied full config above, but ensure idempotent subnet
+            Invoke-External $cli @('--update',$n.Name,'--subnet',$n.Subnet,'--netmask','255.255.255.0','--dhcp',($n.Dhcp?'yes':'no'))
+            if ($n.Type -eq 'nat') { Invoke-External $cli @('--nat',$n.Name,'on') }
+            else { Invoke-External $cli @('--nat',$n.Name,'off') }
+        }
+    }
+}
+
+# Restart services for NAT/DHCP where applicable
+$services = 'VMnetDHCP','VMware NAT Service'
+foreach($s in $services){
+    $svc = Get-Service -Name $s -ErrorAction SilentlyContinue
+    if($svc){
+        if($PSCmdlet.ShouldProcess($s,'restart')){
+            Stop-Service $svc -ErrorAction SilentlyContinue
+            Start-Service $svc -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+$rows = @()
+foreach($n in $nets){
+    $ip = (Get-NetIPConfiguration -InterfaceAlias $n.Name -ErrorAction SilentlyContinue).IPv4Address.IPAddress
+    $rows += [pscustomobject]@{VMnet=$n.Name;Type=$n.Type;Subnet=$n.Subnet;Dhcp=($n.Dhcp?'ON':'OFF');HostIP=$ip}
+}
+$rows | Format-Table -AutoSize

--- a/scripts/deploy-nessus-essentials.ps1
+++ b/scripts/deploy-nessus-essentials.ps1
@@ -1,11 +1,29 @@
 # Deploy Nessus Essentials on k3s and add a hosts entry.
 param(
   [string]$Ns      = "soc",
-  [string]$LbIp    = "172.22.10.61",
+  [string]$LbIp,
   [string]$HostName = "nessus.lab.local"
 )
 $ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
+
+if (-not $IsWindows) {
+  throw 'deploy-nessus-essentials.ps1 can only run on Windows.'
+}
+
 function K { kubectl $args }
+
+function Get-DotEnv {
+  param([string]$Path = '.env')
+  $map=@{}
+  if(Test-Path $Path){
+    Get-Content $Path | Where-Object {$_ -and $_ -notmatch '^\s*#'} | ForEach-Object {
+      if($_ -match '^([^=]+)=(.*)$'){ $map[$matches[1].Trim()]=$matches[2].Trim() }
+    }
+  }
+  return $map
+}
+$envMap = Get-DotEnv '.env'
+if(-not $LbIp){ $LbIp = $envMap.NESSUS_LB_IP; if(-not $LbIp){ $LbIp = '172.22.10.61' } }
 
 # Ensure namespace exists
 K get ns $Ns 2>$null | Out-Null; if ($LASTEXITCODE -ne 0) { K create ns $Ns | Out-Null }
@@ -17,7 +35,7 @@ $svc = (Get-Content "k8s\apps\nessus\service.yaml" -Raw) -replace '172\.22\.10\.
 $svc | K apply -f -
 
 # Wait for external IP
-Write-Host "Waiting for LoadBalancer IP..."
+  Write-Output "Waiting for LoadBalancer IP..."
 $ip = ""
 for ($i=0; $i -lt 60; $i++) {
   $ip = K -n $Ns get svc nessus -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
@@ -33,9 +51,9 @@ $filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -not
 $block = @("# SOC-9000 BEGIN", "$ip $HostName", "# SOC-9000 END")
 Set-Content -Path $hosts -Value ($filtered + $block) -Force
 
-Write-Host "`nOpen: https://$HostName:8834"
-Write-Host "Setup steps:"
-Write-Host "  1) Choose 'Nessus Essentials', request/enter activation code."
-Write-Host "  2) Create the admin account."
-Write-Host "  3) Start a basic scan against the VICTIM segment (172.22.30.0/24)."
-Write-Host "`nNote: Container is ephemeral—if the pod is recreated, you'll re-enter activation/admin."
+Write-Output "`nOpen: https://$HostName:8834"
+Write-Output "Setup steps:"
+Write-Output "  1) Choose 'Nessus Essentials', request/enter activation code."
+Write-Output "  2) Create the admin account."
+Write-Output "  3) Start a basic scan against the VICTIM segment (172.22.30.0/24)."
+Write-Output "`nNote: Container is ephemeral—if the pod is recreated, you'll re-enter activation/admin."

--- a/scripts/host-prepare.ps1
+++ b/scripts/host-prepare.ps1
@@ -24,106 +24,8 @@ $packer = FindExe "packer.exe" @("C:\Program Files\HashiCorp\Packer\packer.exe")
 $drive = Get-PSDrive -Name E -ErrorAction SilentlyContinue
 $freeGB = if($drive){ [math]::Round($drive.Free/1GB,2) } else { 0 }
 
-# VMware networks required
-$need = "VMnet8","VMnet20","VMnet21","VMnet22","VMnet23"
-
-# Attempt automatic network creation if VMware's network utilities are available
-$vmnetcfgcli = FindExe "vmnetcfgcli.exe" @(
-  "C:\Program Files (x86)\VMware\VMware Workstation\vmnetcfgcli.exe",
-  "C:\Program Files\VMware\VMware Workstation\vmnetcfgcli.exe"
-)
-$vnetlib = FindExe "vnetlib.exe" @(
-  "C:\Program Files (x86)\VMware\VMware Workstation\vnetlib.exe",
-  "C:\Program Files\VMware\VMware Workstation\vnetlib.exe"
-)
-$editor = FindExe "vmnetcfg.exe" @(
-  "C:\Program Files (x86)\VMware\VMware Workstation\vmnetcfg.exe",
-  "C:\Program Files\VMware\VMware Workstation\vmnetcfg.exe"
-)
-
-function Get-VMnetNames {
-  if ($vnetlib) {
-    try {
-      & $vnetlib -- listNetworks 2>$null |
-        Where-Object { $_ -match '^(VMnet\d+)' } |
-        ForEach-Object { $matches[1] }
-    } catch { @() }
-  } else {
-    Get-NetAdapter -Name 'VMware Network Adapter VMnet*' -Physical:$false -ErrorAction SilentlyContinue |
-      ForEach-Object { if ($_.Name -match '(VMnet\d+)') { $matches[1] } }
-  }
-}
-$have = Get-VMnetNames
-$missing = $need | Where-Object { $_ -notin $have }
-
-if ($missing) {
-  $nets = @(
-    @{Name='VMnet8';  Type='nat';      Subnet='192.168.37.0'; Dhcp=$true},
-    @{Name='VMnet20'; Type='hostonly'; Subnet='172.22.10.0';  Dhcp=$false},
-    @{Name='VMnet21'; Type='hostonly'; Subnet='172.22.20.0';  Dhcp=$false},
-    @{Name='VMnet22'; Type='hostonly'; Subnet='172.22.30.0';  Dhcp=$false},
-    @{Name='VMnet23'; Type='hostonly'; Subnet='172.22.40.0';  Dhcp=$false}
-  )
-  if ($vnetlib) {
-    function Invoke-VNetLib([string[]]$args) {
-      & $vnetlib -- @args 2>$null | Out-Null
-      if ($LASTEXITCODE -ne 0) { throw "vnetlib $($args -join ' ') failed ($LASTEXITCODE)" }
-    }
-    foreach ($n in $nets) {
-      if ($missing -contains $n.Name) {
-        try {
-          Invoke-VNetLib @("addNetwork", $n.Name)
-          Invoke-VNetLib @("setSubnet", $n.Name, $n.Subnet, "255.255.255.0")
-          Invoke-VNetLib @("setDhcp", $n.Name, ($n.Dhcp ? 'on' : 'off'))
-          if ($n.Type -eq 'nat') {
-            Invoke-VNetLib @("setNat", $n.Name, 'on')
-          } else {
-            Invoke-VNetLib @("setNat", $n.Name, 'off')
-          }
-          Invoke-VNetLib @("updateAdapter", $n.Name)
-          Write-Host "Configured $($n.Name) via vnetlib" -ForegroundColor Green
-        } catch {
-          Write-Warning "Failed to configure $($n.Name): $($_.Exception.Message)"
-        }
-      }
-    }
-  } elseif ($vmnetcfgcli) {
-    foreach ($n in $nets) {
-      if ($missing -contains $n.Name) {
-        try {
-          & $vmnetcfgcli --add $n.Name --type $n.Type --subnet $n.Subnet --netmask 255.255.255.0 --dhcp ($n.Dhcp ? 'yes' : 'no') 2>$null | Out-Null
-          Write-Host "Configured $($n.Name) via vmnetcfgcli" -ForegroundColor Green
-        } catch {
-          Write-Warning "Failed to configure $($n.Name): $($_.Exception.Message)"
-        }
-      }
-    }
-  }
-  try {
-    Get-Service -Name 'VMware NAT Service','VMware DHCP Service' -ErrorAction SilentlyContinue | Restart-Service -Force -ErrorAction SilentlyContinue
-  } catch {}
-  Start-Sleep -Seconds 3
-  $have = Get-VMnetNames
-  $missing = $need | Where-Object { $_ -notin $have }
-}
-
-if ($missing) {
-  if ($editor) { Start-Process $editor -Verb runAs }
-  Write-Host "Manual VMware network configuration required:" -ForegroundColor Yellow
-  Write-Host "   - VMnet8  : NAT (DHCP ON)"
-  Write-Host "   - VMnet20 : Host-only 172.22.10.0/24, DHCP OFF"
-  Write-Host "   - VMnet21 : Host-only 172.22.20.0/24, DHCP OFF"
-  Write-Host "   - VMnet22 : Host-only 172.22.30.0/24, DHCP OFF"
-  Write-Host "   - VMnet23 : Host-only 172.22.40.0/24, DHCP OFF"
-  do {
-    $choice = Read-Host "[D]one, let's go / [N]ot working yet, restart later"
-    if ($choice -match '^[Nn]') { Write-Host "Exiting. Re-run after configuring networks."; exit 1 }
-    $have = Get-VMnetNames
-    $missing = $need | Where-Object { $_ -notin $have }
-    if ($missing) { Write-Warning "Still missing: $($missing -join ', ')" }
-  } while ($missing)
-}
-
+# VMware network configuration
+& (Join-Path $PSScriptRoot 'configure-vmnet.ps1')
 # WSL / Ansible (best effort)
 $wsl = (wsl -l -v 2>$null) -join "`n"
 if (-not $wsl) {
@@ -156,7 +58,7 @@ $rows = @(
  @{Item="vmrun.exe"; Detail=($vmrun ?? "MISSING")}
  @{Item="Packer"; Detail=($packer ?? "MISSING")}
  @{Item="Disk E:"; Detail="$freeGB GB free (>= 300 GB rec.)"}
- @{Item="VMware nets"; Detail=($(if($missing){ "Missing: "+($missing -join ', ') } else { "OK: VMnet8,20,21,22,23" }))}
+ @{Item="VMware nets"; Detail="VMnet8,20,21,22,23"}
  @{Item="WSL"; Detail=($(if($wsl){$wsl.Trim()}else{"Install: wsl --install -d Ubuntu-22.04"}))}
  @{Item="Ansible (WSL)"; Detail=($(if($ans){$ans.Trim()}else{"In WSL: apt install python3-pip python3-venv openssh-client && pip install --user ansible==9.*"}))}
  @{Item="SSH key"; Detail=($(if(Test-Path $sshKey){$sshKey}else{"MISSING"}))}
@@ -165,15 +67,6 @@ $rows | % { "{0,-16} {1}" -f $_.Item, $_.Detail }
 
 Write-Host "`nNext steps:"
 $step = 1
-if ($missing) {
-  Write-Host "${step}) Virtual Network Editor (Admin):"
-  Write-Host "   - VMnet8  : NAT (DHCP ON)"
-  Write-Host "   - VMnet20 : Host-only 172.22.10.0/24, DHCP OFF"
-  Write-Host "   - VMnet21 : Host-only 172.22.20.0/24, DHCP OFF"
-  Write-Host "   - VMnet22 : Host-only 172.22.30.0/24, DHCP OFF"
-  Write-Host "   - VMnet23 : Host-only 172.22.40.0/24, DHCP OFF"
-  $step++
-}
 Write-Host "${step}) Place downloads in ${IsoDir}:"
 Write-Host "   - pfSense CE ISO (Netgate account required)"
 Write-Host "   - Ubuntu 22.04 (AMD64) -> $(Join-Path $IsoDir 'ubuntu-22.04.iso')"

--- a/scripts/hosts-add.ps1
+++ b/scripts/hosts-add.ps1
@@ -1,25 +1,51 @@
 # Adds lab hostnames to Windows hosts file.
-param([string]$TraefikIP = "172.22.10.60")
 $ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
-function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
 
-# Try to get Portainer LB IP (may take a moment after Chunk 3)
-$portainerIP = ""
-try { $portainerIP = K -n portainer get svc portainer -o jsonpath='{.status.loadBalancer.ingress[0].ip}' } catch { }
+if (-not $IsWindows) {
+  throw 'hosts-add.ps1 can only run on Windows.'
+}
+
+function Get-DotEnv {
+  param([string]$Path = '.env')
+  $map=@{}
+  if(Test-Path $Path){
+    Get-Content $Path | Where-Object {$_ -and $_ -notmatch '^\s*#'} | ForEach-Object {
+      if($_ -match '^([^=]+)=(.*)$'){ $map[$matches[1].Trim()]=$matches[2].Trim() }
+    }
+  }
+  return $map
+}
+
+function K { param([Parameter(ValueFromRemainingArguments)]$KArgs) kubectl @KArgs }
+
+$envMap = Get-DotEnv (Join-Path $PSScriptRoot '..\.env')
+
+function Get-LBIP {
+  param($Svc,$Ns,$EnvVar,$Default)
+  $ip=""
+    try { $ip = K -n $Ns get svc $Svc -o jsonpath='{.status.loadBalancer.ingress[0].ip}' } catch { Write-Verbose $_ }
+  if(-not $ip -and $envMap[$EnvVar]){ $ip = $envMap[$EnvVar] }
+  if(-not $ip){ $ip = $Default }
+  return $ip
+}
+
+$traefikIP = Get-LBIP 'traefik' 'kube-system' 'TRAEFIK_LB_IP' '172.22.10.60'
+$nessusIP  = Get-LBIP 'nessus'  'soc'         'NESSUS_LB_IP'  '172.22.10.61'
 
 $entries = @(
-  "$TraefikIP caldera.lab.local",
-  "$TraefikIP dvwa.lab.local"
+  "$traefikIP wazuh.lab.local",
+  "$traefikIP thehive.lab.local",
+  "$traefikIP cortex.lab.local",
+  "$traefikIP caldera.lab.local",
+  "$traefikIP dvwa.lab.local",
+  "$traefikIP portainer.lab.local",
+  "$nessusIP nessus.lab.local"
 )
-if ($portainerIP) { $entries += "$portainerIP portainer.lab.local" }
 
-$hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
-$orig = Get-Content $hosts -ErrorAction Stop
-
-# Remove old SOC-9000 block if present
-$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
-$block = @("# SOC-9000 BEGIN") + $entries + @("# SOC-9000 END")
-
-Set-Content -Path $hosts -Value ($filtered + $block) -Force
-Write-Host "Hosts file updated:"
-$block | ForEach-Object { "  $_" | Write-Host }
+  $hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
+  $orig = Get-Content $hosts -ErrorAction Stop
+  $filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+  $block = @("# SOC-9000 BEGIN") + $entries + @("# SOC-9000 END")
+  Set-Content -Path $hosts -Value ($filtered + $block) -Force
+  Write-Output "Hosts file updated:"
+  $block | ForEach-Object { "  $_" | Write-Output }

--- a/scripts/hosts-refresh.ps1
+++ b/scripts/hosts-refresh.ps1
@@ -1,42 +1,50 @@
 # Rebuild a single SOC-9000 hosts block based on current cluster state
 $ErrorActionPreference="Stop"; Set-StrictMode -Version Latest
+
+if (-not $IsWindows) {
+  throw 'hosts-refresh.ps1 can only run on Windows.'
+}
+
 function K { kubectl $args }
 
-$entries = @()
-# Traefik (k3s default namespace)
-$ns = "kube-system"
-try { K -n $ns get svc traefik | Out-Null } catch { $ns = "traefik" }
-$traefikIP = K -n $ns get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
-if (!$traefikIP) { $traefikIP = "172.22.10.60" }
-$entries += @(
+function Get-DotEnv {
+  param([string]$Path = '.env')
+  $map=@{}
+  if(Test-Path $Path){
+    Get-Content $Path | Where-Object {$_ -and $_ -notmatch '^\s*#'} | ForEach-Object {
+      if($_ -match '^([^=]+)=(.*)$'){ $map[$matches[1].Trim()]=$matches[2].Trim() }
+    }
+  }
+  return $map
+}
+$envMap = Get-DotEnv '.env'
+
+function Get-LBIP {
+  param($Svc,$Ns,$EnvVar,$Default)
+  $ip=""
+  try { $ip = K -n $Ns get svc $Svc -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null } catch { Write-Verbose $_ }
+  if(-not $ip -and $envMap[$EnvVar]){ $ip = $envMap[$EnvVar] }
+  if(-not $ip){ $ip = $Default }
+  return $ip
+}
+
+$traefikIP = Get-LBIP 'traefik' 'kube-system' 'TRAEFIK_LB_IP' '172.22.10.60'
+$nessusIP  = Get-LBIP 'nessus'  'soc'         'NESSUS_LB_IP'  '172.22.10.61'
+
+$entries = @(
   "$traefikIP wazuh.lab.local",
   "$traefikIP thehive.lab.local",
   "$traefikIP cortex.lab.local",
   "$traefikIP caldera.lab.local",
-  "$traefikIP dvwa.lab.local"
+  "$traefikIP dvwa.lab.local",
+  "$traefikIP portainer.lab.local",
+  "$nessusIP nessus.lab.local"
 )
 
-# Portainer
-$portIP = K -n portainer get svc portainer -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
-if ($portIP) { $entries += "$portIP portainer.lab.local" }
-
-# Nessus container
-$nessusSVCIP = K -n soc get svc nessus -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
-if ($nessusSVCIP) { $entries += "$nessusSVCIP nessus.lab.local" }
-
-# Nessus VM (fallback)
-$envPath = ".env"
-if (Test-Path $envPath) {
-  (Get-Content $envPath | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
-    if ($_ -match '^NESSUS_VM_IP=(.*)$'){ $entries += "$( $matches[1] ) nessus.lab.local" }
-  }
-}
-
-# Write hosts block
 $hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
-$orig = Get-Content $hosts
-$filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
-$block = @("# SOC-9000 BEGIN") + ($entries | Sort-Object -Unique) + @("# SOC-9000 END")
-Set-Content -Path $hosts -Value ($filtered + $block) -Force
-Write-Host "Hosts updated:"
-$block | % { "  $_" | Write-Host }
+  $orig = Get-Content $hosts
+  $filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
+  $block = @("# SOC-9000 BEGIN") + ($entries | Sort-Object -Unique) + @("# SOC-9000 END")
+  Set-Content -Path $hosts -Value ($filtered + $block) -Force
+  Write-Output "Hosts updated:"
+  $block | ForEach-Object { "  $_" | Write-Output }

--- a/scripts/install-prereqs.ps1
+++ b/scripts/install-prereqs.ps1
@@ -1,5 +1,5 @@
 <#
-    install-prereqs.ps1: Installs Git and PowerShell 7 if they are not already present.
+    install-prereqs.ps1: Installs PowerShell 7, Packer, kubectl, and Git if they are not already present.
 #>
 
 [CmdletBinding()]
@@ -45,13 +45,31 @@ if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
 if (-not (Get-Command packer -ErrorAction SilentlyContinue)) {
     Write-Host "Packer not found. Installing via winget..." -ForegroundColor Cyan
     try {
-        winget install --id HashiCorp.Packer --accept-package-agreements --accept-source-agreements
-        Refresh-Path
+    winget install --id HashiCorp.Packer --accept-package-agreements --accept-source-agreements
+    Refresh-Path
     } catch {
         Write-Warning "Failed to install Packer via winget. You may need to install it manually."
     }
 } else {
     Write-Host "Packer already installed." -ForegroundColor Green
+}
+
+# kubectl
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    Write-Host "kubectl not found. Installing via winget..." -ForegroundColor Cyan
+    try {
+        winget install --id Kubernetes.kubectl --source winget --accept-package-agreements --accept-source-agreements
+        Refresh-Path
+        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) {
+            Write-Warning "winget returned exit code $LASTEXITCODE for kubectl"
+            $failed = $true
+        }
+    } catch {
+        Write-Warning "Failed to install kubectl via winget. You may need to install it manually."
+        $failed = $true
+    }
+} else {
+    Write-Host "kubectl already installed." -ForegroundColor Green
 }
 
 # Git

--- a/scripts/nessus-vm-build-and-config.ps1
+++ b/scripts/nessus-vm-build-and-config.ps1
@@ -1,36 +1,57 @@
 # Builds the Nessus VM with Packer, runs the Ansible role, and adds a hosts entry.
 $ErrorActionPreference = "Stop"; Set-StrictMode -Version Latest
-function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
 
-# Load .env
-if (!(Test-Path ".env")) { throw ".env not found. Copy .env.example to .env first." }
-(Get-Content ".env" | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
-  if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+function Get-DotEnv {
+  param([string]$Path = '.env')
+  if(!(Test-Path $Path)){ throw ".env not found. Copy .env.example to .env first." }
+  $map=@{}
+  Get-Content $Path | Where-Object {$_ -and $_ -notmatch '^\s*#'} | ForEach-Object {
+    if($_ -match '^([^=]+)=(.*)$'){ $map[$matches[1].Trim()] = $matches[2].Trim() }
+  }
+  return $map
 }
+
+function Convert-ToWSLPath {
+  param([string]$WinPath)
+  if($WinPath -match '^([A-Za-z]):\\(.*)'){
+    $drive = $matches[1].ToLower()
+    $rest = $matches[2].Replace('\\','/')
+    return "/mnt/$drive/$rest"
+  }
+  return $WinPath.Replace('\\','/')
+}
+
+$envMap = Get-DotEnv '.env'
+$required = 'ARTIFACTS_DIR','VMNET_SOC','PFSENSE_SOC_IP','NESSUS_VM_IP','NESSUS_VM_CPUS','NESSUS_VM_RAM_MB'
+foreach($r in $required){ if(-not $envMap[$r]){ throw ".env missing $r" } }
+
+function K { param([Parameter(ValueFromRemainingArguments)]$args) kubectl @args }
 
 # Build with Packer
 pushd packer\nessus-vm
 packer init .
-packer build -force -var "vmnet=$env:VMNET_SOC" -var "ip_addr=$env:NESSUS_VM_IP" -var "ip_gw=$env:PFSENSE_SOC_IP" -var "ip_dns=$env:PFSENSE_SOC_IP" `
-  -var "cpus=$env:NESSUS_VM_CPUS" -var "memory_mb=$env:NESSUS_VM_RAM_MB" .
+packer build -force -var "vmnet=$($envMap.VMNET_SOC)" -var "ip_addr=$($envMap.NESSUS_VM_IP)" -var "ip_gw=$($envMap.PFSENSE_SOC_IP)" -var "ip_dns=$($envMap.PFSENSE_SOC_IP)" `
+  -var "cpus=$($envMap.NESSUS_VM_CPUS)" -var "memory_mb=$($envMap.NESSUS_VM_RAM_MB)" .
 popd
 
 # Start VM
-$vmx = Join-Path $env:ARTIFACTS_DIR "nessus-vm\nessus-vm.vmx"
+$vmx = Join-Path $envMap.ARTIFACTS_DIR "nessus-vm\nessus-vm.vmx"
 $vmrun = @("C:\Program Files (x86)\VMware\VMware Workstation\vmrun.exe","C:\Program Files\VMware\VMware Workstation\vmrun.exe") | ? { Test-Path $_ } | Select-Object -First 1
 if (-not $vmrun) { throw "vmrun not found" }
 & $vmrun -T ws start $vmx nogui | Out-Null
 
-# Run Ansible role from WSL (uses /mnt/e path to copy .deb)
-$inv = "/mnt/e/SOC-9000/SOC-9000/ansible/inventory.ini"
-$play= "/mnt/e/SOC-9000/SOC-9000/ansible/site-nessus.yml"
+# Run Ansible role from WSL
+$repo = Resolve-Path "$PSScriptRoot/.."
+$wslRepo = Convert-ToWSLPath $repo
+$inv = "$wslRepo/ansible/inventory.ini"
+$play= "$wslRepo/ansible/site-nessus.yml"
 wsl bash -lc "ansible-playbook -i '$inv' '$play'"
 
 # Add hosts mapping for convenience
 $hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
 $orig = Get-Content $hosts
 $filtered = $orig | Where-Object { $_ -notmatch '^# SOC-9000 BEGIN' -and $_ -notmatch '^# SOC-9000 END' }
-$block = @("# SOC-9000 BEGIN", "$($env:NESSUS_VM_IP) nessus.lab.local", "# SOC-9000 END")
+$block = @("# SOC-9000 BEGIN", "$($envMap.NESSUS_VM_IP) nessus.lab.local", "# SOC-9000 END")
 Set-Content -Path $hosts -Value ($filtered + $block) -Force
 
 Write-Host "`nDone. Open: https://nessus.lab.local:8834"

--- a/scripts/verify-networking.ps1
+++ b/scripts/verify-networking.ps1
@@ -1,0 +1,56 @@
+# Verify VMware networking and hosts configuration for SOC-9000
+[CmdletBinding()]
+param()
+$ErrorActionPreference='Stop'
+Set-StrictMode -Version Latest
+
+if (-not $IsWindows) {
+    throw 'verify-networking.ps1 can only run on Windows.'
+}
+
+function Find-Exe {
+    param([string]$Name,[string[]]$Candidates)
+    foreach($c in $Candidates){ if(Test-Path $c){return $c} }
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    return $null
+}
+
+$cli = Find-Exe 'vnetlib64.exe' @(
+    'C:\Program Files (x86)\VMware\VMware Workstation\vnetlib64.exe',
+    'C:\Program Files\VMware\VMware Workstation\vnetlib64.exe'
+)
+if(-not $cli){ $cli = Find-Exe 'vmnetcfgcli.exe' @('C:\Program Files (x86)\VMware\VMware Workstation\vmnetcfgcli.exe','C:\Program Files\VMware\VMware Workstation\vmnetcfgcli.exe') }
+
+$nets = 'VMnet8','VMnet20','VMnet21','VMnet22','VMnet23'
+$adapters = Get-NetAdapter | Where-Object {$_.Name -in $nets}
+if($adapters.Count -ne $nets.Count){ throw 'Missing VMnet adapters' }
+$adapters | Where-Object {$_.Status -ne 'Up'} | ForEach-Object { throw "Adapter $($_.Name) not Up" }
+
+$subnets = @{VMnet20='172.22.10.0';VMnet21='172.22.20.0';VMnet22='172.22.30.0';VMnet23='172.22.40.0'}
+foreach($kv in $subnets.GetEnumerator()){
+    $cfg = Get-NetIPConfiguration -InterfaceAlias $kv.Key
+    if($cfg.IPv4Address.IPAddress -notlike ($kv.Value.TrimEnd('0')+'1*') -and $cfg.IPv4Address.IPAddress -notlike ($kv.Value.TrimEnd('0')+'2*')){
+        throw "Unexpected IP on $($kv.Key): $($cfg.IPv4Address.IPAddress)"
+    }
+    if($cli){
+        $info = & $cli -- getvnet ($kv.Key.ToLower()) 2>$null
+        if($info -notmatch [regex]::Escape($kv.Value)){ throw "vnetlib mismatch on $($kv.Key)" }
+    }
+}
+
+# Services
+foreach($s in 'VMware NAT Service','VMnetDHCP'){
+    $svc = Get-Service $s -ErrorAction SilentlyContinue
+    if($svc -and $svc.Status -ne 'Running'){ throw "$s not running" }
+}
+
+# Hosts file block
+$hosts = Get-Content "$env:SystemRoot\System32\drivers\etc\hosts"
+$block = $hosts | Where-Object { $_ -match '^# SOC-9000 BEGIN' -or $_ -match '^# SOC-9000 END' -or $_ -match 'lab.local' }
+if($block -notmatch '# SOC-9000 BEGIN'){ throw 'Hosts block missing' }
+$names = 'wazuh.lab.local','thehive.lab.local','cortex.lab.local','caldera.lab.local','dvwa.lab.local','portainer.lab.local','nessus.lab.local'
+foreach($n in $names){ if($block -notmatch $n){ throw "Hosts missing $n" } }
+$names | ForEach-Object { Resolve-DnsName -Name $_ -ErrorAction Stop | Out-Null }
+
+Write-Output 'Networking verification passed'


### PR DESCRIPTION
## Summary
- add configurable VMware VMnet automation and verification scripts
- refactor host prep, bring-up, and hosts management to consume .env and new networking helpers
- document networking workflow in README
- provide explicit installation hints for packer and kubectl during lab bring-up preflight
- harden networking scripts with Windows guards and cleaner output
- auto-install kubectl via prerequisite script and simplify host preparation guidance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm audit`
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path scripts"`


------
https://chatgpt.com/codex/tasks/task_e_689da600e33c832d9efd65b65283e161