### PR TITLE
chore: use FQCN in Ansible tasks

### DIFF
--- a/ansible/roles/containerhost_rsyslog/tasks/main.yml
+++ b/ansible/roles/containerhost_rsyslog/tasks/main.yml
@@ -1,32 +1,32 @@
 ---
 - name: Ensure rsyslog installed and enabled
   become: yes
-  apt:
+  ansible.builtin.apt:
     name: rsyslog
     state: present
     update_cache: yes
 
 - name: Create pfsense log dir
   become: yes
-  file:
+  ansible.builtin.file:
     path: /var/log/pfsense
     state: directory
     mode: '0755'
 
 - name: Configure rsyslog listener for pfSense on MGMT IP
   become: yes
-  copy:
+  ansible.builtin.copy:
     dest: /etc/rsyslog.d/10-pfsense.conf
     mode: '0644'
     content: |
       module(load="imudp")
-      input(type="imudp" port="514" address="{{ lookup('env','CH_IP_MGMT') | default('172.22.10.10') }}")
+      input(type="imudp" port="514" address="{{ lookup('env', 'CH_IP_MGMT') | default('172.22.10.10') }}")
       template(name="PFLine" type="string" string="%msg%\n")
-      if ($fromhost-ip == "{{ lookup('env','PFSENSE_MGMT_IP') | default('172.22.10.1') }}") then {
+      if ($fromhost-ip == "{{ lookup('env', 'PFSENSE_MGMT_IP') | default('172.22.10.1') }}") then {
         action(type="omfile" file="/var/log/pfsense/pfsense.log" template="PFLine")
         stop
       }
 
 - name: Restart rsyslog
   become: yes
-  service: { name: rsyslog, state: restarted, enabled: yes }
+  ansible.builtin.service: { name: rsyslog, state: restarted, enabled: yes }

--- a/ansible/roles/containerhost_wazuh_agent/tasks/main.yml
+++ b/ansible/roles/containerhost_wazuh_agent/tasks/main.yml
@@ -1,28 +1,32 @@
 ---
+- name: Add Wazuh GPG key
+  become: yes
+  ansible.builtin.apt_key:
+    url: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    state: present
+    keyring: /usr/share/keyrings/wazuh.gpg
+
 - name: Add Wazuh APT repo
   become: yes
-  shell: |
-    curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH \
-      | gpg --dearmor \
-      | tee /usr/share/keyrings/wazuh.gpg >/dev/null
-    echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" \
-      | tee /etc/apt/sources.list.d/wazuh.list
-  args: { creates: /etc/apt/sources.list.d/wazuh.list }
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main"
+    state: present
+    filename: wazuh
 
 - name: Install wazuh-agent
   become: yes
-  apt: { name: wazuh-agent, state: present, update_cache: yes }
+  ansible.builtin.apt: { name: wazuh-agent, state: present, update_cache: yes }
 
 - name: Configure manager address
   become: yes
-  replace:
+  ansible.builtin.replace:
     path: /var/ossec/etc/ossec.conf
     regexp: '<address>.*</address>'
-    replace: '<address>{{ lookup("env","WAZUH_MANAGER_LB_IP") | default("172.22.10.62") }}</address>'
+    replace: '<address>{{ lookup("env", "WAZUH_MANAGER_LB_IP") | default("172.22.10.62") }}</address>'
 
 - name: Ensure localfile for pfSense logs
   become: yes
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: /var/ossec/etc/ossec.conf
     marker: "<!-- PF-SOC-9000 {mark} -->"
     block: |
@@ -33,4 +37,4 @@
 
 - name: Enable & restart agent
   become: yes
-  service: { name: wazuh-agent, state: restarted, enabled: yes }
+  ansible.builtin.service: { name: wazuh-agent, state: restarted, enabled: yes }

--- a/ansible/roles/nessus_vm/tasks/register.yml
+++ b/ansible/roles/nessus_vm/tasks/register.yml
@@ -8,11 +8,11 @@
 
 - name: Register Nessus with activation code (if provided)
   ansible.builtin.command:
-    cmd: /opt/nessus/sbin/nessuscli fetch --register {{ lookup('env','NESSUS_ACTIVATION_CODE') }}
+    cmd: /opt/nessus/sbin/nessuscli fetch --register {{ lookup('env', 'NESSUS_ACTIVATION_CODE') }}
   when: lookup('env','NESSUS_ACTIVATION_CODE') | length > 0
   become: yes
-  register: reg_cmd
-  changed_when: "'Registration successful' in reg_cmd.stdout or reg_cmd.rc == 0"
+  register: nessus_vm_reg_cmd
+  changed_when: "'Registration successful' in nessus_vm_reg_cmd.stdout or nessus_vm_reg_cmd.rc == 0"
 
 - name: Wait for Nessus web UI to become ready
   ansible.builtin.uri:
@@ -20,21 +20,24 @@
     method: GET
     validate_certs: no
     status_code: 200,302,401
-  register: ui_check
-  until: ui_check is succeeded
+  register: nessus_vm_ui_check
+  until: nessus_vm_ui_check is succeeded
   retries: 30
   delay: 5
 
 - name: Optionally create admin user
   ansible.builtin.shell: |
     set -o pipefail
-    /opt/nessus/sbin/nessuscli adduser --login {{ lookup('env','NESSUS_ADMIN_USER') }} --password {{ lookup('env','NESSUS_ADMIN_PASS') }} --admin yes <<EOF
+    /opt/nessus/sbin/nessuscli adduser \
+      --login {{ lookup('env', 'NESSUS_ADMIN_USER') }} \
+      --password {{ lookup('env', 'NESSUS_ADMIN_PASS') }} \
+      --admin yes <<EOF
     y
     EOF
   args:
     executable: /bin/bash
-  when: 
-    - lookup('env','NESSUS_ADMIN_USER') | length > 0
-    - lookup('env','NESSUS_ADMIN_PASS') | length > 0
+  when:
+    - lookup('env', 'NESSUS_ADMIN_USER') | length > 0
+    - lookup('env', 'NESSUS_ADMIN_PASS') | length > 0
   become: yes
   changed_when: false


### PR DESCRIPTION
## Summary
- replace Wazuh repo shell command with apt modules for idempotent setup
- tidy Nessus VM registration task with prefixed variables and line wrapping

## Testing
- `npm audit --production --audit-level=high`
- `npm test` *(fails: Missing script "test")*
- `python -m ansiblelint ansible/roles/containerhost_rsyslog/tasks/main.yml ansible/roles/containerhost_wazuh_agent/tasks/main.yml ansible/roles/nessus_vm/tasks/register.yml`
- `yamllint ansible k8s`

------
https://chatgpt.com/codex/tasks/task_e_689ef30424cc832dbe7d81a4206fb9ba