### PR TITLE
fix: avoid PowerShell automatic variable collision

### DIFF
--- a/scripts/configure-vmnet.ps1
+++ b/scripts/configure-vmnet.ps1
@@ -7,7 +7,8 @@
   atomically via vnetlib64.exe, restarts NAT/DHCP, disables DHCP on host-only
   VMnets (20–23), and verifies adapters/services.
 #>
-[CmdletBinding(SupportsShouldProcess)]
+# CmdletBinding without SupportsShouldProcess to avoid duplicate WhatIf
+[CmdletBinding()]
 param(
   [string]$Vmnet8Subnet   = "192.168.37.0",
   [string]$Vmnet8Mask     = "255.255.255.0",
@@ -56,6 +57,7 @@ function Find-VNetLib {
 
 function Invoke-VMnet([string[]]$Args) {
   Write-Verbose ("vnetlib64 -- " + ($Args -join ' '))
+  $global:LASTEXITCODE = 0
   & $script:VNetLib -- @Args
   if ($LASTEXITCODE -ne 0) { throw "vnetlib failed ($LASTEXITCODE): $($Args -join ' ')" }
 }

--- a/scripts/reset-lab.ps1
+++ b/scripts/reset-lab.ps1
@@ -19,11 +19,11 @@ if ($Hard) {
   # Load .env for CH_IP_MGMT
   if (Test-Path ".env") {
     (Get-Content ".env" | ? {$_ -and $_ -notmatch '^\s*#'}) | % {
-      if ($_ -match '^\s*([^=]+)=(.*)$'){ $env:$($matches[1].Trim())=$matches[2].Trim() }
+      if ($_ -match '^\s*([^=]+)=(.*)$'){ Set-Item -Path "Env:$($matches[1].Trim())" -Value $matches[2].Trim() }
     }
   }
-  $host = $env:CH_IP_MGMT; if(-not $host){ $host="172.22.10.10" }
-  wsl bash -lc "ssh -o StrictHostKeyChecking=no labadmin@$host 'sudo rm -rf /var/lib/rancher/k3s/storage/* /srv/nfs/* 2>/dev/null || true'"
+  $hostIp = $env:CH_IP_MGMT; if(-not $hostIp){ $hostIp="172.22.10.10" }
+  wsl bash -lc "ssh -o StrictHostKeyChecking=no labadmin@$hostIp 'sudo rm -rf /var/lib/rancher/k3s/storage/* /srv/nfs/* 2>/dev/null || true'"
 }
 
 Write-Host "Re-applying platform & apps..."


### PR DESCRIPTION
## Summary
- avoid assigning to PowerShell automatic variable `$host` in `reset-lab.ps1`
- load `.env` values using `Set-Item` for clarity
- remove `SupportsShouldProcess` from `configure-vmnet.ps1` to prevent duplicate `-WhatIf` parameter
- initialize `$LASTEXITCODE` in `configure-vmnet.ps1` to satisfy strict mode checks

## Testing
- `pwsh -NoProfile -Command "Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -Path ./scripts/configure-vmnet.ps1"`
- `npm test` *(fails: Missing script: "test")*
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_689f11ed5a88832da42b784c3d73e6f4