### PR TITLE
Ignore empty .env values in VMnet configuration

### DIFF
--- a/scripts/configure-vmnet.ps1
+++ b/scripts/configure-vmnet.ps1
@@ -41,7 +41,10 @@ function Read-DotEnv([string]$Path) {
   $m=@{}; Get-Content $Path | ForEach-Object {
     if ($_ -match '^\s*#' -or $_ -match '^\s*$') { return }
     $k,$v = $_ -split '=',2
-    if ($v -ne $null){ $m[$k.Trim()]=$v.Trim() }
+    if ($v -ne $null) {
+      $val = $v.Trim()
+      if ($val) { $m[$k.Trim()] = $val }
+    }
   }; $m
 }
 


### PR DESCRIPTION
## Summary
- ignore empty values when parsing `.env` so defaults remain intact

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm audit`
- `pip-audit` *(fails: SSLError: certificate verify failed)*
- `pwsh -NoProfile -Command "Install-Module PSScriptAnalyzer -Scope CurrentUser -Force"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f28ee5214832d87b968dc94e6e44e