### PR TITLE
fix: use ascii characters in setup script

### DIFF
--- a/scripts/setup-soc9000.ps1
+++ b/scripts/setup-soc9000.ps1
@@ -144,7 +144,7 @@ $isoList = Get-RequiredIsos -EnvMap $envMap -IsoDir $envMap['ISO_DIR']
 if ($isoList.Count -gt 0) {
   Prompt-MissingIsosLoop -IsoList $isoList -IsoDir $envMap['ISO_DIR']
 } else {
-  Write-Host "No required ISO keys were found in .env — skipping ISO check."
+  Write-Host "No required ISO keys were found in .env - skipping ISO check."
 }
 
 try {
@@ -188,4 +188,4 @@ catch {
 }
 
 Write-Host ""
-Write-Host "All requested steps completed."
+Write-Host 'All requested steps completed.'


### PR DESCRIPTION
## Summary
- replace non-ASCII dash in ISO check message to prevent parser errors
- quote final completion message with single quotes for simplicity

## Testing
- `npm audit`
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path scripts/setup-soc9000.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7765e3ec832da31a014e4a95e413