### PR TITLE
Fix ISO detection and automate Ubuntu download

### DIFF
--- a/checksums.txt
+++ b/checksums.txt
@@ -4,9 +4,8 @@
 # or:
 #   <filename>  <SHA256>
 
-# Examples (replace with vendor values)
-# jammy 22.04.5:
-# 9f4f08a5f8c2a34e3e9c9d7fd7b...<truncated>...  ubuntu-22.04.iso
+# Official SHA256 checksums
+9bc6028870aef3f74f4e16b900008179e78b130e6b0b9a140635434a46aa98b0  ubuntu-22.04.iso
 # pfSense CE 2.7.3:
 # <official sha256>  pfsense.iso
 # Windows 11 Eval:

--- a/scripts/setup-soc9000.ps1
+++ b/scripts/setup-soc9000.ps1
@@ -4,6 +4,12 @@ param([switch]$ManualNetwork)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+trap {
+  Write-Error $_
+  Read-Host 'Press ENTER to exit'
+  exit 1
+}
+
 function Ensure-Admin {
   $id  = [Security.Principal.WindowsIdentity]::GetCurrent()
   $pri = New-Object Security.Principal.WindowsPrincipal($id)
@@ -46,7 +52,7 @@ function Get-RequiredIsos {
   param([hashtable]$EnvMap,[string]$IsoDir)
   $pairs = @()
   foreach ($key in $EnvMap.Keys) {
-    if ($key -like 'ISO_*' -or $key -eq 'NESSUS_DEB') {
+    if (($key -like 'ISO_*' -and $key -ne 'ISO_DIR') -or $key -eq 'NESSUS_DEB') {
       $name = $EnvMap[$key]
       if ([string]::IsNullOrWhiteSpace($name)) { continue }
       $pairs += [pscustomobject]@{
@@ -64,7 +70,7 @@ function Prompt-MissingIsosLoop {
   param([pscustomobject[]]$IsoList, [string]$IsoDir)
   while ($true) {
     $missing = $IsoList | Where-Object { -not $_.Exists }
-    if ($missing.Count -eq 0) { return }
+    if (($missing | Measure-Object).Count -eq 0) { return }
     Write-Warning "You need to download the following ISOs/packages before continuing:"
     $missing | ForEach-Object {
       Write-Host ("  - {0}  ->  {1}" -f $_.Key, $_.FileName)
@@ -140,6 +146,23 @@ if (-not (Test-Path $envPath)) {
 $envMap = Read-DotEnv $envPath
 if (-not $envMap.ContainsKey('ISO_DIR')) { $envMap['ISO_DIR'] = $IsoDir }
 
+# Ensure base images are present and validated
+$dlScript = Join-Path $RepoRoot 'scripts\download-isos.ps1'
+if (Test-Path $dlScript) {
+  Write-Host 'Ensuring ISO downloads...'
+  & pwsh -NoProfile -ExecutionPolicy Bypass -File $dlScript -IsoDir $envMap['ISO_DIR']
+  if ($LASTEXITCODE -ne 0) { throw "download-isos.ps1 failed with exit code $LASTEXITCODE" }
+  Write-Host 'ISO download step: OK'
+}
+
+$vhScript = Join-Path $RepoRoot 'scripts\verify-hashes.ps1'
+if (Test-Path $vhScript) {
+  Write-Host 'Verifying ISO checksums...'
+  & pwsh -NoProfile -ExecutionPolicy Bypass -File $vhScript -IsoDir $envMap['ISO_DIR'] -Strict
+  if ($LASTEXITCODE -ne 0) { throw "verify-hashes.ps1 failed with exit code $LASTEXITCODE" }
+  Write-Host 'ISO checksum verification: OK'
+}
+
 $isoList = Get-RequiredIsos -EnvMap $envMap -IsoDir $envMap['ISO_DIR']
 if ($isoList.Count -gt 0) {
   Prompt-MissingIsosLoop -IsoList $isoList -IsoDir $envMap['ISO_DIR']
@@ -184,8 +207,10 @@ try {
 catch {
   Write-Error ("A follow-up step failed: {0}" -f $_.Exception.Message)
   Write-Host "Fix the issue above and re-run this script. Nothing destructive was done."
+  Read-Host 'Press ENTER to exit'
   exit 1
 }
 
 Write-Host ""
 Write-Host 'All requested steps completed.'
+Read-Host 'Press ENTER to exit'

--- a/tests/Unit.IsoKeys.Tests.ps1
+++ b/tests/Unit.IsoKeys.Tests.ps1
@@ -6,7 +6,7 @@ Describe "ISO key detection" -Tag 'unit' {
       param([hashtable]$EnvMap,[string]$IsoDir)
       $pairs = @()
       foreach ($key in $EnvMap.Keys) {
-        if ($key -like 'ISO_*' -or $key -eq 'NESSUS_DEB') {
+        if (($key -like 'ISO_*' -and $key -ne 'ISO_DIR') -or $key -eq 'NESSUS_DEB') {
           $name = $EnvMap[$key]
           if ([string]::IsNullOrWhiteSpace($name)) { continue }
           $full = Join-Path $IsoDir $name
@@ -19,13 +19,30 @@ Describe "ISO key detection" -Tag 'unit' {
       'ISO_UBUNTU' = 'ubuntu-24.04.1-live-server-amd64.iso'
       'ISO_PFSENSE' = 'pfSense-CE-2.7.2-RELEASE-amd64.iso'
       'NESSUS_DEB' = 'Nessus-10.8.1-ubuntu1404_amd64.deb'
+      'ISO_DIR' = 'ignore-me'
       'OTHER_KEY' = 'ignored.txt'
     }
     $isoDir = if ($IsWindows) { 'C:\isos' } else { '/isos' }
     $pairs = Get-RequiredIsosLocal -EnvMap $envMap -IsoDir $isoDir
     ($pairs | Measure-Object).Count | Should -Be 3
+    ($pairs | Where-Object Key -eq 'ISO_DIR').Count | Should -Be 0
     ($pairs | Where-Object Key -eq 'ISO_UBUNTU').FullPath | Should -BeExactly (Join-Path $isoDir 'ubuntu-24.04.1-live-server-amd64.iso')
     ($pairs | Where-Object Key -eq 'NESSUS_DEB').FileName | Should -BeExactly 'Nessus-10.8.1-ubuntu1404_amd64.deb'
+  }
+}
+
+Describe "Prompt-MissingIsosLoop" -Tag 'unit' {
+  It "returns immediately when all ISOs exist" {
+    function Prompt-MissingIsosLoopLocal {
+      param([pscustomobject[]]$IsoList,[string]$IsoDir)
+      $missing = $IsoList | Where-Object { -not $_.Exists }
+      if (($missing | Measure-Object).Count -eq 0) { return $true } else { return $false }
+    }
+    $list = @(
+      [pscustomobject]@{Key='ISO_1'; FileName='a.iso'; FullPath='/isos/a.iso'; Exists=$true},
+      [pscustomobject]@{Key='ISO_2'; FileName='b.iso'; FullPath='/isos/b.iso'; Exists=$true}
+    )
+    Prompt-MissingIsosLoopLocal -IsoList $list -IsoDir '/isos' | Should -BeTrue
   }
 }
 


### PR DESCRIPTION
## Summary
- exclude ISO_DIR from required ISO checks
- download Ubuntu ISO automatically and verify checksums
- update ISO key tests and add Ubuntu SHA256 checksum
- keep setup script open after errors or completion for easier troubleshooting
- prevent null checks from crashing ISO re-check loop and add unit test

## Testing
- `npm audit --production`
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path 'scripts/setup-soc9000.ps1'; Invoke-ScriptAnalyzer -Path 'tests/Unit.IsoKeys.Tests.ps1'"`
- `pwsh -NoProfile -Command "Invoke-Pester -Tag 'unit'"`


------
https://chatgpt.com/codex/tasks/task_e_689f8e3200c0832d9589b8efaadf04e5