### PR TITLE
fix setup script iso count

### DIFF
--- a/scripts/setup-soc9000.ps1
+++ b/scripts/setup-soc9000.ps1
@@ -163,7 +163,7 @@ if (Test-Path $vhScript) {
   Write-Host 'ISO checksum verification: OK'
 }
 
-$isoList = Get-RequiredIsos -EnvMap $envMap -IsoDir $envMap['ISO_DIR']
+$isoList = @(Get-RequiredIsos -EnvMap $envMap -IsoDir $envMap['ISO_DIR'])
 if ($isoList.Count -gt 0) {
   Prompt-MissingIsosLoop -IsoList $isoList -IsoDir $envMap['ISO_DIR']
 } else {


### PR DESCRIPTION
## Summary
- ensure Get-RequiredIsos results are always treated as an array before checking Count

## Testing
- `npm audit`
- Tests and lints could not be executed due to missing PowerShell dependencies


------
https://chatgpt.com/codex/tasks/task_e_689f96815a04832db95f292982897f9b