### PR TITLE
Streamline ISO handling and reinforce VMnet configuration

### DIFF
--- a/scripts/generate-vmnet-profile.ps1
+++ b/scripts/generate-vmnet-profile.ps1
@@ -86,8 +86,12 @@ foreach($def in @(@{n=20;s=$Vmnet20Subnet},@{n=21;s=$Vmnet21Subnet},@{n=22;s=$Vm
 }
 $text = ($lines -join "`r`n")
 $art = $artDir
-if (-not $OutFile) { $OutFile = Join-Path $art 'vmnet-profile.txt' }
-New-Item -ItemType Directory -Force -Path (Split-Path $OutFile -Parent) | Out-Null
+if (-not $OutFile) {
+  New-Item -ItemType Directory -Force -Path $art | Out-Null
+  $OutFile = Join-Path $art 'vmnet-profile.txt'
+} else {
+  New-Item -ItemType Directory -Force -Path (Split-Path $OutFile -Parent) | Out-Null
+}
 Set-Content -Path $OutFile -Value $text -Encoding ASCII
 $logDir = Join-Path $repoRoot 'logs'; New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 $ts = Get-Date -Format "yyyyMMdd-HHmmss"; $logCopy = Join-Path $logDir "vmnet-profile-$ts.txt"

--- a/scripts/setup-soc9000.ps1
+++ b/scripts/setup-soc9000.ps1
@@ -37,12 +37,6 @@ function Read-DotEnv([string]$Path) {
   return $m
 }
 
-function Show-Step([string]$Msg) {
-  Write-Host ""
-  Write-Host "==== $Msg ====" -ForegroundColor Cyan
-}
-
-
 function Run-IfExists([string]$ScriptPath,[string]$FriendlyName) {
   if (Test-Path $ScriptPath) {
     Write-Host ("Running {0} ..." -f $FriendlyName)
@@ -52,130 +46,129 @@ function Run-IfExists([string]$ScriptPath,[string]$FriendlyName) {
   }
 }
 
-function Find-VNetLib {
-  foreach ($p in @(
-    "C:\\Program Files (x86)\\VMware\\VMware Workstation\\vnetlib64.exe",
-    "C:\\Program Files\\VMware\\VMware Workstation\\vnetlib64.exe"
-  )) { if (Test-Path $p) { return $p } }
-  return $null
-}
-
-function Configure-VMnets([string]$RepoRoot,[string]$ArtifactsDir) {
-  if ($ManualNetwork) { throw "Manual network configuration requested." }
-  $cfg = Join-Path $RepoRoot 'scripts\\configure-vmnet.ps1'
-  if (-not (Test-Path $cfg)) { throw "Missing configure-vmnet.ps1" }
-  & pwsh -NoProfile -ExecutionPolicy Bypass -File $cfg
-  $cfgExit = $LASTEXITCODE
-  if ($cfgExit -eq 0) {
-    Write-Host "VMware networking: OK" -ForegroundColor Green
-    return
+function Ensure-VMwareNetworkServices {
+  $svcNames = @(
+    @{ Name='VMnetNatSvc'; Display='VMware NAT Service'   },
+    @{ Name='VMnetDHCP';   Display='VMware DHCP Service'  }
+  )
+  foreach ($s in $svcNames) {
+    $svc = Get-Service -Name $s.Name -ErrorAction SilentlyContinue
+    if (-not $svc) { $svc = Get-Service -DisplayName $s.Display -ErrorAction SilentlyContinue }
+    if ($svc) {
+      try {
+        $wmi = Get-WmiObject -Class Win32_Service -Filter "Name='$($svc.Name)'" -ErrorAction SilentlyContinue
+        if ($wmi -and $wmi.StartMode -ne 'Auto') { $null = $wmi.ChangeStartMode('Automatic') }
+      } catch {}
+      if ($svc.Status -ne 'Running') {
+        try { Start-Service -InputObject $svc -ErrorAction Stop } catch { Write-Warning "Failed to start '$($svc.Name)': $($_.Exception.Message)" }
+        $deadline = (Get-Date).AddSeconds(20)
+        do {
+          Start-Sleep -Milliseconds 500
+          $svc.Refresh()
+        } while ($svc.Status -ne 'Running' -and (Get-Date) -lt $deadline)
+      }
+      if ($svc.Status -ne 'Running') { throw "Service '$($svc.Name)' failed to reach Running state." }
+    } else {
+      Write-Warning "VMware service '$($s.Name)' not found."
+    }
   }
-  Write-Warning ("configure-vmnet.ps1 failed ({0}); attempting fallback" -f $cfgExit)
-
-  $gen = Join-Path $RepoRoot 'scripts\\generate-vmnet-profile.ps1'
-  if (-not (Test-Path $gen)) { throw "Missing generate-vmnet-profile.ps1" }
-  $profile = Join-Path $ArtifactsDir 'vmnet-profile.txt'
-  Write-Host "Generating profile..." -ForegroundColor Yellow
-  & pwsh -NoProfile -ExecutionPolicy Bypass -File $gen -OutFile $profile
-  $genExit = $LASTEXITCODE
-  if ($genExit -ne 0) { throw "generate-vmnet-profile.ps1 failed ($genExit)" }
-
-  $vnetlib = Find-VNetLib
-  if (-not $vnetlib) { throw "vnetlib64.exe not found. Install VMware Workstation Pro 17+ and re-run." }
-
-  Write-Host "Importing..." -ForegroundColor Yellow
-  & $vnetlib -- stop dhcp
-  $stopDhcp = $LASTEXITCODE
-  & $vnetlib -- stop nat
-  $stopNat  = $LASTEXITCODE
-  & $vnetlib -- import $profile
-  $importExit = $LASTEXITCODE
-  & $vnetlib -- start dhcp
-  $startDhcp = $LASTEXITCODE
-  & $vnetlib -- start nat
-  $startNat = $LASTEXITCODE
-
-  foreach($s in @("VMware NAT Service","VMnetDHCP")){
-    $svc = Get-Service -Name $s -ErrorAction SilentlyContinue
-    if($svc -and $svc.StartType -eq 'Disabled'){ Set-Service -Name $s -StartupType Automatic }
-    try{ Start-Service -Name $s -ErrorAction SilentlyContinue }catch{}
-  }
-
-  if ($importExit -eq 0) {
-    Write-Host "VMware networking (import): OK" -ForegroundColor Green
-    return
-  }
-
-  Write-Warning ("vnetlib import failed ({0}). Launching Virtual Network Editor." -f $importExit)
-  $vmnetcfg = @(
-    "C:\\Program Files (x86)\\VMware\\VMware Workstation\\vmnetcfg.exe",
-    "C:\\Program Files\\VMware\\VMware Workstation\\vmnetcfg.exe"
-  ) | Where-Object { Test-Path $_ } | Select-Object -First 1
-  if ($vmnetcfg) { Start-Process -FilePath $vmnetcfg -Wait }
-  Read-Host 'Press ENTER when done' | Out-Null
 }
 
 # --- main ---
 
 Ensure-Admin
 
-$ScriptRoot = Split-Path -Parent $PSCommandPath
-$RepoRoot   = (Resolve-Path (Join-Path $ScriptRoot '..')).Path
-$envPath    = Join-Path $RepoRoot '.env'
-if (-not (Test-Path $envPath)) {
-  $example = Join-Path $RepoRoot '.env.example'
-  if (Test-Path $example) {
-    Copy-Item $example $envPath -Force
-    Write-Host "Created .env from template." -ForegroundColor Yellow
+# Resolve repo root and defaults
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$EExists  = Test-Path 'E:\'
+
+$DefaultLabRoot   = if ($EExists) { 'E:\SOC-9000' } else { $RepoRoot }
+$DefaultArtifacts = if ($EExists) { 'E:\SOC-9000\artifacts\network' } else { (Join-Path $RepoRoot 'artifacts\network') }
+$DefaultIsoDir    = if ($EExists) { 'E:\SOC-9000-Install\isos' } else { (Join-Path $RepoRoot 'install\isos') }
+
+# Parse .env (optional)
+$EnvFile = Join-Path $RepoRoot '.env'
+$EnvMap = @{}
+if (Test-Path $EnvFile) {
+  Get-Content $EnvFile | Where-Object { $_ -match '^\s*[^#].+=.+$' } | ForEach-Object {
+    $k,$v = $_ -split '=',2; $EnvMap[$k.Trim()] = $v.Trim()
   }
 }
-$envMap = Read-DotEnv $envPath
-$Defaults = if (Test-Path 'E:\\') {
-  @{ LAB_ROOT='E:\\SOC-9000'; ARTIFACTS_DIR='E:\\SOC-9000\\artifacts\\network'; ISO_DIR='E:\\SOC-9000-Install\\isos' }
-} else {
-  @{ LAB_ROOT=$RepoRoot; ARTIFACTS_DIR=(Join-Path $RepoRoot 'artifacts\\network'); ISO_DIR=(Join-Path $RepoRoot 'install\\isos') }
-}
 
-$LabRoot = if ($envMap.ContainsKey('LAB_ROOT')) { $envMap['LAB_ROOT'] } else { $Defaults.LAB_ROOT }
-$ArtifactsDir = if ($PSBoundParameters.ContainsKey('ArtifactsDir')) { $ArtifactsDir } elseif ($envMap.ContainsKey('ARTIFACTS_DIR')) { $envMap['ARTIFACTS_DIR'] } else { $Defaults.ARTIFACTS_DIR }
-$IsoDir = if ($PSBoundParameters.ContainsKey('IsoDir')) { $IsoDir } elseif ($envMap.ContainsKey('ISO_DIR')) { $envMap['ISO_DIR'] } else { $Defaults.ISO_DIR }
-$LogDir = Join-Path $LabRoot 'logs'
-$null = New-Item -ItemType Directory -Force -Path $LabRoot, $IsoDir, $ArtifactsDir, $LogDir
+$LabRoot   = $EnvMap['LAB_ROOT']      ?? $DefaultLabRoot
+$Artifacts = $ArtifactsDir ?? ($EnvMap['ARTIFACTS_DIR'] ?? $DefaultArtifacts)
+$IsoRoot   = $IsoDir       ?? ($EnvMap['ISO_DIR']       ?? $DefaultIsoDir)
+
+# Ensure dirs exist
+New-Item -ItemType Directory -Force -Path $LabRoot,$Artifacts,$IsoRoot | Out-Null
 
 try { Stop-Transcript | Out-Null } catch {}
+$LogDir = Join-Path $LabRoot 'logs'
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 $ts  = Get-Date -Format 'yyyyMMdd-HHmmss'
 $log = Join-Path $LogDir "setup-soc9000-$ts.log"
 Start-Transcript -Path $log -Force | Out-Null
 
-Show-Step "Ensuring ISO downloads"
-$dlScript = Join-Path $RepoRoot 'scripts\\download-isos.ps1'
-if (Test-Path $dlScript) {
-  & pwsh -NoProfile -ExecutionPolicy Bypass -File $dlScript -IsoDir $IsoDir
-  if ($LASTEXITCODE -ne 0) { throw "download-isos.ps1 failed ($LASTEXITCODE)" }
-}
-Show-Step "Verifying checksums"
-$vhScript = Join-Path $RepoRoot 'scripts\\verify-hashes.ps1'
-if (Test-Path $vhScript) {
-  & pwsh -NoProfile -ExecutionPolicy Bypass -File $vhScript -IsoDir $IsoDir
-}
+Write-Host "`n==== Ensuring ISO downloads ====" -ForegroundColor Cyan
+& pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $RepoRoot 'scripts\download-isos.ps1') -IsoDir $IsoRoot
+if ($LASTEXITCODE -ne 0) { throw "download-isos.ps1 failed with exit code $LASTEXITCODE" }
 
-Show-Step "Configuring VMware networks"
-try {
-  Configure-VMnets -RepoRoot $RepoRoot -ArtifactsDir $ArtifactsDir
-} catch {
-  Write-Warning ("Automatic network setup failed: {0}" -f $_.Exception.Message)
+Write-Host "`n==== ISO summary (informational) ====" -ForegroundColor Cyan
+Get-ChildItem -Path $IsoRoot -File | Sort-Object Length -Descending | Select-Object Name,Length,LastWriteTime | Format-Table
+
+Write-Host "`n==== Configuring VMware networks ====" -ForegroundColor Cyan
+if ($ManualNetwork) {
+  Write-Host "Manual network configuration requested."
   Write-Host "Please configure VMnets manually via Virtual Network Editor and press ENTER to continue."
   Read-Host 'Press ENTER when done' | Out-Null
+} else {
+  $cfg = Join-Path $RepoRoot 'scripts\configure-vmnet.ps1'
+  try {
+    if (Test-Path $cfg) {
+      & pwsh -NoProfile -ExecutionPolicy Bypass -File $cfg
+      if ($LASTEXITCODE -ne 0) { throw "configure-vmnet.ps1 failed ($LASTEXITCODE)." }
+      Ensure-VMwareNetworkServices
+    } else {
+      throw "configure-vmnet.ps1 not found"
+    }
+  }
+  catch {
+    Write-Warning "$($_.Exception.Message); attempting fallback"
+    $gen = Join-Path $RepoRoot 'scripts\generate-vmnet-profile.ps1'
+    $profilePath = Join-Path $Artifacts 'vmnet-profile.txt'
+
+    Write-Host "Generating profile..."
+    & pwsh -NoProfile -ExecutionPolicy Bypass -File $gen -OutFile $profilePath
+    if ($LASTEXITCODE -ne 0) { throw "generate-vmnet-profile.ps1 failed ($LASTEXITCODE)." }
+    Write-Host "VMnet profile written: $profilePath"
+
+    $vnetlib = @(
+      "C:\\Program Files\\VMware\\VMware Workstation\\vnetlib64.exe",
+      "C:\\Program Files (x86)\\VMware\\VMware Workstation\\vnetlib64.exe"
+    ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (-not $vnetlib) { throw "vnetlib64.exe not found" }
+
+    Write-Host "Importing..."
+    $p = Start-Process -FilePath $vnetlib -ArgumentList @('--','stop','dhcp') -Wait -PassThru;  if ($p.ExitCode -ne 0) { throw "stop dhcp failed: $($p.ExitCode)" }
+    $p = Start-Process -FilePath $vnetlib -ArgumentList @('--','stop','nat')  -Wait -PassThru;  if ($p.ExitCode -ne 0) { throw "stop nat failed: $($p.ExitCode)" }
+    $p = Start-Process -FilePath $vnetlib -ArgumentList @('--','import',"$profilePath") -Wait -PassThru; if ($p.ExitCode -ne 0) { throw "import failed: $($p.ExitCode)" }
+    $p = Start-Process -FilePath $vnetlib -ArgumentList @('--','start','dhcp') -Wait -PassThru; if ($p.ExitCode -ne 0) { Write-Warning "start dhcp exit $($p.ExitCode)" }
+    $p = Start-Process -FilePath $vnetlib -ArgumentList @('--','start','nat')  -Wait -PassThru; if ($p.ExitCode -ne 0) { Write-Warning "start nat exit $($p.ExitCode)" }
+
+    Ensure-VMwareNetworkServices
+    Write-Host "VMware networking (import): OK"
+  }
 }
 
-Show-Step "Verifying networking"
-Run-IfExists (Join-Path $RepoRoot 'scripts\\verify-networking.ps1') 'verify-networking.ps1'
+Write-Host "`n==== Verifying networking ====" -ForegroundColor Cyan
+& pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $RepoRoot 'scripts\verify-networking.ps1')
+if ($LASTEXITCODE -ne 0) { throw "verify-networking.ps1 exited with code $LASTEXITCODE" }
 
-Show-Step "Bootstrapping WSL and Ansible"
-Run-IfExists (Join-Path $RepoRoot 'scripts\\wsl-prepare.ps1')       'wsl-prepare.ps1'
-Run-IfExists (Join-Path $RepoRoot 'scripts\\wsl-bootstrap.ps1')     'wsl-bootstrap.ps1'
-Run-IfExists (Join-Path $RepoRoot 'scripts\\copy-ssh-key-to-wsl.ps1') 'copy-ssh-key-to-wsl.ps1'
-Run-IfExists (Join-Path $RepoRoot 'scripts\\lab-up.ps1')            'lab-up.ps1'
+Write-Host "`n==== Bootstrapping WSL and Ansible ====" -ForegroundColor Cyan
+Run-IfExists (Join-Path $RepoRoot 'scripts\wsl-prepare.ps1')       'wsl-prepare.ps1'
+Run-IfExists (Join-Path $RepoRoot 'scripts\wsl-bootstrap.ps1')     'wsl-bootstrap.ps1'
+Run-IfExists (Join-Path $RepoRoot 'scripts\copy-ssh-key-to-wsl.ps1') 'copy-ssh-key-to-wsl.ps1'
+Run-IfExists (Join-Path $RepoRoot 'scripts\lab-up.ps1')            'lab-up.ps1'
 
 Write-Host ""
 Write-Host 'All requested steps completed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Simplify setup paths with portable E:\ overrides and automatic directory creation
- Drop checksum prompts and make ISO downloads informational only
- Harden VMnet import by avoiding `$LASTEXITCODE`, ensuring VMware services start, and defaulting profiles to `artifacts\network`

## Testing
- `npm audit --audit-level=critical`
- `pwsh -NoProfile -Command "Import-Module PSScriptAnalyzer -ErrorAction Stop; Invoke-ScriptAnalyzer -Path 'scripts/setup-soc9000.ps1','scripts/configure-vmnet.ps1','scripts/generate-vmnet-profile.ps1'"` *(fails: pwsh not installed)*
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a07362c0e4832da624e039c3055158