### PR TITLE
Align tests with environment defaults and lint YAML

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 INSTALL_ROOT=C:\SOC-9000-Install
 CONFIG_NETWORK_DIR=C:\SOC-9000-Install\config\network
 ISO_DIR=C:\SOC-9000-Install\isos
+LAB_ROOT=C:\SOC-9000-Lab
+REPO_ROOT=C:\SOC-9000-Repo
+ARTIFACTS_DIR=C:\SOC-9000-Install\artifacts
+TEMP_DIR=C:\SOC-9000-Install\tmp
+NESSUS_DEB=nessus_latest_amd64.deb
+BACKUP_DIR=E:\\SOC-9000\\backups
+SNAPSHOT_RETENTION=5
 
 # NAT (defaults used by scripts if omitted)
 NAT_SUBNET=192.168.186.0

--- a/ansible/roles/nessus_vm/tasks/main.yml
+++ b/ansible/roles/nessus_vm/tasks/main.yml
@@ -50,7 +50,10 @@
     {{ (lookup('env','NESSUS_ADMIN_USER') | default('')) | length > 0 and
        (lookup('env','NESSUS_ADMIN_PASS') | default('')) | length > 0 }}
   ansible.builtin.shell: |
-    /opt/nessus/sbin/nessuscli adduser --login {{ lookup('env','NESSUS_ADMIN_USER') }} --password {{ lookup('env','NESSUS_ADMIN_PASS') }} --admin yes <<EOF
+    /opt/nessus/sbin/nessuscli adduser \
+      --login {{ lookup('env','NESSUS_ADMIN_USER') }} \
+      --password {{ lookup('env','NESSUS_ADMIN_PASS') }} \
+      --admin yes <<EOF
     y
     EOF
   args:

--- a/k8s/nessus-deployment-patch.yaml
+++ b/k8s/nessus-deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - name: register-nessus
           image: alpine:3.20
-          command: ["/bin/sh","-c"]
+          command: ["/bin/sh", "-c"]
           args:
             - |
               echo "Registering Nessus..."

--- a/scripts/generate-vmnet-profile.ps1
+++ b/scripts/generate-vmnet-profile.ps1
@@ -38,7 +38,9 @@ $envFile  = if ($EnvPath) { $EnvPath } elseif (Test-Path (Join-Path $RepoRoot '.
 $envMap   = if ($envFile) { Read-DotEnv $envFile } else { @{} }
 
 $EExists      = Test-Path 'E:\'
-$InstallRoot  = if ($envMap['INSTALL_ROOT']) { $envMap['INSTALL_ROOT'] } else { if ($EExists) { 'E:\SOC-9000-Install' } else { Join-Path ${env:SystemDrive} 'SOC-9000-Install' } }
+$sysDrive = $env:SystemDrive
+if (-not $sysDrive) { $sysDrive = '/' }
+$InstallRoot  = if ($envMap['INSTALL_ROOT']) { $envMap['INSTALL_ROOT'] } else { if ($EExists) { 'E:\SOC-9000-Install' } else { Join-Path $sysDrive 'SOC-9000-Install' } }
 $ProfileDir   = Join-Path $InstallRoot 'config\network'
 $LogDir       = Join-Path $InstallRoot 'logs\installation'
 New-Item -ItemType Directory -Force -Path $ProfileDir,$LogDir | Out-Null

--- a/tests/Integration.VMware.Tests.ps1
+++ b/tests/Integration.VMware.Tests.ps1
@@ -1,13 +1,15 @@
 # Tags: integration
 [CmdletBinding()] param()
-function Find-VNetLib {
-  foreach($p in @(
-    "C:\Program Files (x86)\VMware\VMware Workstation\vnetlib64.exe",
-    "C:\Program Files\VMware\VMware Workstation\vnetlib64.exe"
-  )){ if (Test-Path $p) { return $p } }
-  $null
-}
 Describe "VMware presence and non-destructive ops" -Tag 'integration' {
+  BeforeAll {
+    function Find-VNetLib {
+      foreach($p in @(
+        "C:\\Program Files (x86)\\VMware\\VMware Workstation\\vnetlib64.exe",
+        "C:\\Program Files\\VMware\\VMware Workstation\\vnetlib64.exe"
+      )) { if (Test-Path $p) { return $p } }
+      $null
+    }
+  }
   It "finds vnetlib64.exe or skips" {
     $v = Find-VNetLib
     if (-not $v) { Set-ItResult -Skipped -Because "vnetlib64.exe not present"; return }
@@ -34,3 +36,4 @@ Describe "VMware presence and non-destructive ops" -Tag 'integration' {
     & $v -- start dhcp; & $v -- start nat
   }
 }
+

--- a/tests/Unit.VMnetProfile.Tests.ps1
+++ b/tests/Unit.VMnetProfile.Tests.ps1
@@ -16,37 +16,45 @@ VMNET21_SUBNET=172.22.20.0
 VMNET22_SUBNET=172.22.30.0
 VMNET23_SUBNET=172.22.40.0
 HOSTONLY_MASK=255.255.255.0
+HOSTONLY_VMNET_IDS=20,21,22,23
 "@ | Set-Content -Path $tmpEnv -Encoding ASCII
     $out = Join-Path ([IO.Path]::GetTempPath()) 'soc9000-vmnet-import.txt'
     $text = . $gen -EnvPath $tmpEnv -OutFile $out -PassThru
     $expected = @"
+add adapter vmnet8
 add vnet vmnet8
 set vnet vmnet8 addr 192.168.186.0
 set vnet vmnet8 mask 255.255.255.0
 set adapter vmnet8 addr 192.168.186.1
+add nat vmnet8
 set nat vmnet8 internalipaddr 192.168.186.2
+add dhcp vmnet8
 update adapter vmnet8
 update nat vmnet8
 update dhcp vmnet8
 
+add adapter vmnet20
 add vnet vmnet20
 set vnet vmnet20 addr 172.22.10.0
 set vnet vmnet20 mask 255.255.255.0
 set adapter vmnet20 addr 172.22.10.1
 update adapter vmnet20
 
+add adapter vmnet21
 add vnet vmnet21
 set vnet vmnet21 addr 172.22.20.0
 set vnet vmnet21 mask 255.255.255.0
 set adapter vmnet21 addr 172.22.20.1
 update adapter vmnet21
 
+add adapter vmnet22
 add vnet vmnet22
 set vnet vmnet22 addr 172.22.30.0
 set vnet vmnet22 mask 255.255.255.0
 set adapter vmnet22 addr 172.22.30.1
 update adapter vmnet22
 
+add adapter vmnet23
 add vnet vmnet23
 set vnet vmnet23 addr 172.22.40.0
 set vnet vmnet23 mask 255.255.255.0


### PR DESCRIPTION
## Summary
- add missing environment variables to `.env.example` for lab, repo, artifacts, and backup paths
- make `generate-vmnet-profile.ps1` handle missing `$env:SystemDrive` and update VMnet profile tests
- clean up VMware integration tests and fix YAML lint issues

## Testing
- `pwsh -Command "Invoke-Pester -Path tests"`
- `npm audit`
- `yamllint .`
- `pwsh -Command "Invoke-ScriptAnalyzer -Path scripts -Recurse"` *(warnings: AvoidUsingWriteHost, PSUseBOMForUnicodeEncodedFile)*

------
https://chatgpt.com/codex/tasks/task_e_68a85c2c5ecc832dbe412e9cbe549066